### PR TITLE
Add priority uniqueness validation to chargen

### DIFF
--- a/game/wod_core/__init__.py
+++ b/game/wod_core/__init__.py
@@ -103,6 +103,12 @@ def chargen(splat_id: str, mode: str = "full", preset: dict | None = None):
         elif result["action"] == "next":
             # Save step data (strip "action" key, keep the rest)
             step_data = {k: v for k, v in result.items() if k != "action"}
+            # Reject invalid priority picks (e.g. the same rank on two groups)
+            # rather than corrupting the downstream allocation pools.
+            ok, msg = state.validate_priority_step(step_name, step_data)
+            if not ok:
+                show_toast(msg)
+                continue
             state.save_step(step_name, step_data)
             state.complete_step(state.current_step)
             state.invalidate_dependents(step_name)

--- a/game/wod_core/chargen.py
+++ b/game/wod_core/chargen.py
@@ -18,6 +18,54 @@ _INVALIDATION_MAP = {
     "ability_priority": ["ability_allocate"],      # Priority pool sizes change
 }
 
+# Priority steps map to the config key holding their rank pool (the dot values
+# for Primary / Secondary / Tertiary). Used to validate that each rank is
+# assigned to exactly one group.
+_PRIORITY_RANK_CONFIG = {
+    "attribute_priority": "attribute_priorities",
+    "ability_priority": "ability_priorities",
+}
+
+
+def validate_priorities(
+    assignment: dict[str, int], expected_ranks: list[int]
+) -> tuple[bool, str]:
+    """Validate a priority-step assignment.
+
+    ``assignment`` maps each group to the rank (dot pool) the player gave it,
+    e.g. ``{"physical": 7, "social": 5, "mental": 3}``. ``expected_ranks`` is
+    the configured set of ranks, e.g. ``[7, 5, 3]`` (Primary, Secondary,
+    Tertiary).
+
+    The three ranks must each go to a different group: no group may be left
+    unassigned, and no two groups may share a rank (e.g. two Primaries).
+
+    Returns ``(ok, message)``; ``message`` is empty when valid.
+    """
+    expected = list(expected_ranks)
+    ranks = list(assignment.values())
+
+    # Every group must receive a rank (0 or missing means unassigned).
+    if len(assignment) < len(expected) or any(not r for r in ranks):
+        return False, "Assign a priority to every group before continuing."
+
+    # Each rank must be distinct. This is the core rule a player can violate if
+    # the UI is bypassed: assigning the same rank (e.g. Primary) to two groups.
+    if len(set(ranks)) != len(ranks):
+        return (
+            False,
+            "Each priority must go to a different group — you cannot assign "
+            "the same rank twice.",
+        )
+
+    # The assigned ranks must be exactly the configured Primary/Secondary/
+    # Tertiary values, each used once.
+    if sorted(ranks) != sorted(expected):
+        ordered = sorted(expected, reverse=True)
+        return False, f"Priorities must be assigned from {ordered}, one each."
+
+    return True, ""
+
 
 class ChargenState:
     """Tracks character creation progress across steps."""
@@ -49,6 +97,23 @@ class ChargenState:
                 dep_index = self.steps.index(dep_step_name)
                 self.completed.discard(dep_index)
                 self.data.pop(dep_step_name, None)
+
+    def validate_priority_step(
+        self, step_name: str, assignment: dict[str, int]
+    ) -> tuple[bool, str]:
+        """Validate a priority assignment for ``step_name`` against config.
+
+        Looks up the configured rank pool for the step (e.g. ``[7, 5, 3]`` for
+        attributes) and checks the assignment uses each rank exactly once.
+        Non-priority steps validate trivially, returning ``(True, "")``.
+        """
+        config_key = _PRIORITY_RANK_CONFIG.get(step_name)
+        if config_key is None:
+            return True, ""
+        expected_ranks = self.get_mode_config().get(config_key)
+        if not expected_ranks:
+            return True, ""
+        return validate_priorities(assignment, expected_ranks)
 
     def get_mode_config(self) -> dict:
         return self.config["modes"].get(self.mode, {})

--- a/tests/test_chargen.py
+++ b/tests/test_chargen.py
@@ -1,7 +1,12 @@
 # tests/test_chargen.py
 import os
 import pytest
-from wod_core.chargen import ChargenState, PointPool, build_character
+from wod_core.chargen import (
+    ChargenState,
+    PointPool,
+    build_character,
+    validate_priorities,
+)
 from wod_core.loader import SplatLoader
 
 GAME_DIR = os.path.join(os.path.dirname(__file__), "..", "game")
@@ -111,6 +116,77 @@ class TestPointPool:
         pool.reset()
         assert pool.remaining == 7
         assert pool.get_all() == {}
+
+
+class TestPriorityValidation:
+    """Priority steps must assign three distinct ranks (issue #14)."""
+
+    def test_valid_distinct_attribute_priorities(self, mage_splat):
+        state = ChargenState("mage", "full", mage_splat.schema, mage_splat.chargen_config, mage_splat)
+        ok, msg = state.validate_priority_step(
+            "attribute_priority", {"physical": 7, "social": 5, "mental": 3}
+        )
+        assert ok is True
+        assert msg == ""
+
+    def test_duplicate_primary_rejected(self, mage_splat):
+        # The exact bug from issue #14: Primary (7) assigned to two groups.
+        state = ChargenState("mage", "full", mage_splat.schema, mage_splat.chargen_config, mage_splat)
+        ok, msg = state.validate_priority_step(
+            "attribute_priority", {"physical": 7, "social": 7, "mental": 3}
+        )
+        assert ok is False
+        assert "same rank" in msg
+
+    def test_incomplete_priority_rejected(self, mage_splat):
+        # One group left unassigned (0 dots).
+        state = ChargenState("mage", "full", mage_splat.schema, mage_splat.chargen_config, mage_splat)
+        ok, msg = state.validate_priority_step(
+            "attribute_priority", {"physical": 7, "social": 5, "mental": 0}
+        )
+        assert ok is False
+        assert msg
+
+    def test_invalid_rank_values_rejected(self, mage_splat):
+        # Distinct, but not the configured 7/5/3 pool.
+        state = ChargenState("mage", "full", mage_splat.schema, mage_splat.chargen_config, mage_splat)
+        ok, msg = state.validate_priority_step(
+            "attribute_priority", {"physical": 7, "social": 5, "mental": 4}
+        )
+        assert ok is False
+        assert msg
+
+    def test_valid_distinct_ability_priorities(self, mage_splat):
+        state = ChargenState("mage", "full", mage_splat.schema, mage_splat.chargen_config, mage_splat)
+        ok, msg = state.validate_priority_step(
+            "ability_priority", {"talents": 13, "skills": 9, "knowledges": 5}
+        )
+        assert ok is True
+
+    def test_duplicate_ability_priority_rejected(self, mage_splat):
+        state = ChargenState("mage", "full", mage_splat.schema, mage_splat.chargen_config, mage_splat)
+        ok, msg = state.validate_priority_step(
+            "ability_priority", {"talents": 13, "skills": 13, "knowledges": 5}
+        )
+        assert ok is False
+        assert "same rank" in msg
+
+    def test_non_priority_step_passes(self, mage_splat):
+        # Steps without a configured rank pool validate trivially.
+        state = ChargenState("mage", "full", mage_splat.schema, mage_splat.chargen_config, mage_splat)
+        ok, msg = state.validate_priority_step("identity", {"name": "Test"})
+        assert ok is True
+        assert msg == ""
+
+    def test_validate_priorities_helper_distinct(self):
+        ok, msg = validate_priorities({"a": 7, "b": 5, "c": 3}, [7, 5, 3])
+        assert ok is True
+        assert msg == ""
+
+    def test_validate_priorities_helper_duplicate(self):
+        ok, msg = validate_priorities({"a": 7, "b": 7, "c": 3}, [7, 5, 3])
+        assert ok is False
+        assert "different group" in msg
 
 
 class TestBuildCharacter:


### PR DESCRIPTION
Closes #14.

## Problem

In full-mode character creation, the player assigns three priority ranks — Primary, Secondary, Tertiary — to the Attribute groups (Physical/Social/Mental) and again to the Ability groups (Talents/Skills/Knowledges). The allocation step then reads each group's dot budget straight from that assignment.

The Ren'Py priority screens *visually* prevented duplicates (they hid already-used ranks), but there was **no logic-layer check** and no test. A bypassed UI, a preset, or a future front-end could assign the same rank (e.g. Primary) to two groups, silently corrupting the downstream allocation pools. Issue #14 (label `engine`, milestone *Chargen Polish*) asks for validation that all three priority ranks are distinct — the chargen design spec also lists "Priority assignment validation" as a required test.

## Change

- **`chargen.py`** — add `validate_priorities(assignment, expected_ranks)`, which requires every group to receive a distinct rank drawn from the configured pool (`[7, 5, 3]` for attributes, `[13, 9, 5]` for abilities). Add `ChargenState.validate_priority_step(step_name, assignment)`, which looks the pool up from config by step name and delegates; non-priority steps validate trivially.
- **`__init__.py`** — wire the check into the `chargen()` step loop. An invalid priority pick now shows a toast and re-displays the step instead of being saved. In normal UI flow this path is never hit (the screen already guarantees distinct, complete picks), so there is no behavior change for valid input — it's a safety net.

## Tests

Added `TestPriorityValidation` (9 cases): valid distinct picks for both attribute and ability steps, duplicate-rank rejection (the exact issue #14 scenario), incomplete assignment, invalid rank values, non-priority-step pass-through, and the standalone helper.

Full suite: **131 passed** (`python -m pytest`).

https://claude.ai/code/session_01EBbEm7F4HXWbitHNVhMKfL

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBbEm7F4HXWbitHNVhMKfL)_