### PR TITLE
Expand Mage Archetype list to full M20 set

### DIFF
--- a/game/splats/mage/chargen.yaml
+++ b/game/splats/mage/chargen.yaml
@@ -115,24 +115,34 @@ traditions:
         description: "Correspondence and Forces — reshape the physical through the digital"
         file: templates/va_reality_hacker.yaml
 
-# Curated subset of M20 Archetypes
+# Full M20 Nature/Demeanor Archetype set.
+# "Monster" is intentionally omitted — it reads as a Vampire (Beast) archetype
+# rather than a Mage one.
 archetypes:
   - Architect
+  - Autocrat
+  - Avant-Garde
   - Bon Vivant
   - Bravo
   - Caregiver
   - Celebrant
+  - Child
   - Competitor
   - Conformist
   - Conniver
   - Curmudgeon
   - Deviant
   - Director
+  - Enigma
+  - Eye of the Storm
+  - Fanatic
   - Gallant
+  - Guru
   - Idealist
   - Judge
   - Loner
   - Martyr
+  - Masochist
   - Pedagogue
   - Penitent
   - Perfectionist


### PR DESCRIPTION
## Summary

Closes #12.

Expands the Nature/Demeanor **Archetype** options in `game/splats/mage/chargen.yaml` from the curated 26-entry subset to the full M20 set (now **34** entries).

### Added
- **M20-specific Archetypes** named in the issue: `Avant-Garde`, `Enigma`, `Eye of the Storm`, `Guru`. (`Idealist` — also named in the issue — was already present.)
- **Remaining standard Archetypes** that were missing from the subset: `Autocrat`, `Child`, `Fanatic`, `Masochist`.

### Omitted
- **`Monster`** — per the issue, this reads as a Vampire (Beast) Archetype rather than a Mage one, so it's deliberately left out. It's the only standard M20 Archetype excluded.

The list stays alphabetized.

## Why no code changes
`ChargenState.get_archetypes()` reads the list straight from config, and the chargen screen (`chargen.rpy`) iterates it to build the Nature/Demeanor pickers — so the new options surface automatically. Nothing validates Nature/Demeanor against the list, and the only hardcoded references elsewhere (`Visionary`, `Architect` in templates/tests/docs) remain valid.

## A note for the reviewer
The issue says to "remove Mage-inappropriate ones (e.g., Monster is more Vampire)." I read that as a single clear exclusion (`Monster`) and kept the rest of the canonical M20 list. `Masochist` is the next most Vampire-flavored entry — it's a legitimate M20 Archetype so I included it, but happy to drop it (or any others) if you'd prefer a tighter Mage-only curation.

## Testing
- `python -m pytest` → **122 passed**
- Verified the YAML parses, the list is alphabetized, has no duplicates, contains all issue-named additions, and excludes `Monster`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JzMuEYroB7cuuLt1SYj3W5)_