### PR TITLE
feat(mage): add Hollow Ones and Orphans as chargen options

### DIFF
--- a/docs/author-guide.md
+++ b/docs/author-guide.md
@@ -573,24 +573,24 @@ The preset dict is merged into the identity step data before the first screen ap
 The `chargen.yaml` file controls everything about character creation:
 
 - **`modes`** -- Define which steps each mode uses, point pools, starting Arete, freebie costs.
-- **`traditions`** -- List of Traditions with affinity Spheres, starting Arete overrides, and template file references.
+- **`traditions`** -- List of Traditions with affinity Spheres, starting Arete overrides, and template file references. The Mage pack ships the nine Traditions plus the Hollow Ones (a quasi-Tradition) and Orphans (unaffiliated Disparates). Orphans use `affinity_sphere: Any` because they choose their own.
 - **`archetypes`** -- Nature/Demeanor options.
 - **`essences`** -- Dynamic, Pattern, Primordial, Questing.
 - **`merits`** / **`flaws`** -- Available during the freebie step, with name, cost, and description.
 
-Example -- adding a new Tradition:
+Example -- adding a new Tradition (here, the Taftani artificers, which the Mage pack does not include by default):
 
 ```yaml
 traditions:
   # ... existing traditions ...
-  - id: hollow_ones
-    name: "Hollow Ones"
-    affinity_sphere: Entropy
-    free_sphere_dot: Entropy
+  - id: taftani
+    name: "Taftani"
+    affinity_sphere: Forces
+    free_sphere_dot: Forces
     templates:
-      - name: "Gothic Poet"
-        description: "Entropy and Mind — find truth in decay and disillusion"
-        file: templates/ho_gothic_poet.yaml
+      - name: "Wonder-Smith"
+        description: "Forces and Matter — bind the elements into living works of art"
+        file: templates/taft_wonder_smith.yaml
 ```
 
 ---

--- a/game/splats/mage/chargen.yaml
+++ b/game/splats/mage/chargen.yaml
@@ -117,6 +117,33 @@ traditions:
         description: "Correspondence and Forces — reshape the physical through the digital"
         file: templates/va_reality_hacker.yaml
 
+  # Quasi-Tradition (Hollow Ones) and unaffiliated mages (Orphans / Disparates).
+  - id: hollow_ones
+    name: "Hollow Ones"
+    affinity_sphere: Entropy
+    free_sphere_dot: Entropy
+    templates:
+      - name: "Gothic Poet"
+        description: "Entropy and Mind — find truth in decay and disillusion"
+        file: templates/ho_gothic_poet.yaml
+      - name: "Deathly Medium"
+        description: "Entropy and Spirit — commune with the dead and the dying world"
+        file: templates/ho_deathly_medium.yaml
+
+  - id: orphans
+    name: "Orphans"
+    # Orphans (the Disparates) Awaken without a Tradition and choose their own
+    # affinity Sphere, so none is fixed here; each template picks its own focus.
+    affinity_sphere: Any
+    free_sphere_dot: null
+    templates:
+      - name: "Self-Taught Sorcerer"
+        description: "Forces and Prime — raw magick reinvented alone, through trial and error"
+        file: templates/orphan_self_taught.yaml
+      - name: "Intuitive Empath"
+        description: "Mind and Life — an untrained psychic who heals and reads by instinct"
+        file: templates/orphan_intuitive_empath.yaml
+
 # Full M20 Nature/Demeanor Archetype set.
 # "Monster" is intentionally omitted — it reads as a Vampire (Beast) archetype
 # rather than a Mage one.

--- a/game/splats/mage/templates/ho_deathly_medium.yaml
+++ b/game/splats/mage/templates/ho_deathly_medium.yaml
@@ -1,0 +1,46 @@
+schema: mage
+template: ho_deathly_medium
+character_type: pc
+identity:
+  name: ""
+  tradition: "Hollow Ones"
+  essence: "Primordial"
+  resonance: "Entropic"
+  nature: "Penitent"
+  demeanor: "Loner"
+traits:
+  attributes:
+    Strength: 1
+    Dexterity: 2
+    Stamina: 2
+    Charisma: 3
+    Manipulation: 2
+    Appearance: 2
+    Perception: 4
+    Intelligence: 2
+    Wits: 3
+  abilities:
+    Awareness: 3
+    Empathy: 2
+    Alertness: 1
+    Occult: 3
+    Meditation: 2
+    Enigmas: 2
+    Expression: 1
+  spheres:
+    Entropy: 3
+    Spirit: 2
+    Mind: 1
+  arete:
+    Arete: 3
+  resonance:
+    Entropic: 2
+  backgrounds:
+    Avatar: 2
+    Mentor: 2
+    Allies: 3
+resources:
+  quintessence: 5
+  paradox: 0
+  willpower: 5
+merits_flaws: []

--- a/game/splats/mage/templates/ho_gothic_poet.yaml
+++ b/game/splats/mage/templates/ho_gothic_poet.yaml
@@ -1,0 +1,47 @@
+schema: mage
+template: ho_gothic_poet
+character_type: pc
+identity:
+  name: ""
+  tradition: "Hollow Ones"
+  essence: "Pattern"
+  resonance: "Entropic"
+  nature: "Visionary"
+  demeanor: "Gallant"
+traits:
+  attributes:
+    Strength: 1
+    Dexterity: 2
+    Stamina: 2
+    Charisma: 3
+    Manipulation: 2
+    Appearance: 3
+    Perception: 3
+    Intelligence: 3
+    Wits: 2
+  abilities:
+    Expression: 3
+    Awareness: 2
+    Empathy: 2
+    Subterfuge: 2
+    Occult: 2
+    Enigmas: 2
+    Academics: 1
+  spheres:
+    Entropy: 3
+    Mind: 2
+    Spirit: 1
+  arete:
+    Arete: 3
+  resonance:
+    Entropic: 2
+  backgrounds:
+    Avatar: 3
+    Contacts: 2
+    Mentor: 2
+resources:
+  quintessence: 4
+  paradox: 0
+  willpower: 5
+merits_flaws:
+  - { name: "Nightmares", type: flaw, value: -1 }

--- a/game/splats/mage/templates/orphan_intuitive_empath.yaml
+++ b/game/splats/mage/templates/orphan_intuitive_empath.yaml
@@ -1,0 +1,46 @@
+schema: mage
+template: orphan_intuitive_empath
+character_type: pc
+identity:
+  name: ""
+  tradition: "Orphans"
+  essence: "Pattern"
+  resonance: "Static"
+  nature: "Caregiver"
+  demeanor: "Conformist"
+traits:
+  attributes:
+    Strength: 1
+    Dexterity: 2
+    Stamina: 2
+    Charisma: 3
+    Manipulation: 2
+    Appearance: 3
+    Perception: 3
+    Intelligence: 2
+    Wits: 2
+  abilities:
+    Empathy: 3
+    Awareness: 2
+    Alertness: 2
+    Subterfuge: 1
+    Meditation: 2
+    Medicine: 2
+    Investigation: 2
+  spheres:
+    Mind: 3
+    Life: 2
+    Entropy: 1
+  arete:
+    Arete: 3
+  resonance:
+    Static: 1
+  backgrounds:
+    Avatar: 2
+    Allies: 3
+    Contacts: 2
+resources:
+  quintessence: 4
+  paradox: 0
+  willpower: 5
+merits_flaws: []

--- a/game/splats/mage/templates/orphan_self_taught.yaml
+++ b/game/splats/mage/templates/orphan_self_taught.yaml
@@ -1,0 +1,47 @@
+schema: mage
+template: orphan_self_taught
+character_type: pc
+identity:
+  name: ""
+  tradition: "Orphans"
+  essence: "Dynamic"
+  resonance: "Dynamic"
+  nature: "Survivor"
+  demeanor: "Loner"
+traits:
+  attributes:
+    Strength: 2
+    Dexterity: 3
+    Stamina: 3
+    Charisma: 2
+    Manipulation: 2
+    Appearance: 2
+    Perception: 3
+    Intelligence: 3
+    Wits: 3
+  abilities:
+    Athletics: 2
+    Alertness: 2
+    Awareness: 2
+    Streetwise: 2
+    Survival: 2
+    Science: 2
+    Occult: 2
+  spheres:
+    Forces: 3
+    Prime: 2
+    Correspondence: 1
+  arete:
+    Arete: 3
+  resonance:
+    Dynamic: 1
+  backgrounds:
+    Avatar: 3
+    Node: 2
+    Resources: 2
+resources:
+  quintessence: 5
+  paradox: 0
+  willpower: 5
+merits_flaws:
+  - { name: "Natural Channel", type: merit, value: 3 }

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -126,7 +126,7 @@ class TestChargenConfigLoading:
         assert splat.chargen_config is not None
         assert "modes" in splat.chargen_config
         assert "traditions" in splat.chargen_config
-        assert len(splat.chargen_config["traditions"]) == 9
+        assert len(splat.chargen_config["traditions"]) == 11
 
     def test_chargen_config_has_all_modes(self):
         loader = SplatLoader(GAME_DIR)
@@ -213,3 +213,44 @@ class TestTemplateExtension:
         # Archmage should allow spheres up to 10
         assert char.schema.get_range("Forces") == (0, 10)
         assert char.identity["name"] == "Archmaster"
+
+
+class TestHollowOnesAndOrphans:
+    """Hollow Ones (quasi-Tradition) and Orphans/Disparates (unaffiliated)."""
+
+    def _tradition(self, splat, trad_id):
+        for t in splat.chargen_config["traditions"]:
+            if t["id"] == trad_id:
+                return t
+        return None
+
+    def test_factions_present_with_affinities(self):
+        loader = SplatLoader(GAME_DIR)
+        splat = loader.load_splat("mage")
+
+        hollow = self._tradition(splat, "hollow_ones")
+        orphans = self._tradition(splat, "orphans")
+        assert hollow is not None
+        assert orphans is not None
+        assert hollow["name"] == "Hollow Ones"
+        assert hollow["affinity_sphere"] == "Entropy"
+        # Orphans choose their own affinity Sphere, so none is fixed.
+        assert orphans["affinity_sphere"] == "Any"
+
+    def test_all_referenced_templates_build(self):
+        loader = SplatLoader(GAME_DIR)
+        splat = loader.load_splat("mage")
+
+        for trad_id in ("hollow_ones", "orphans"):
+            trad = self._tradition(splat, trad_id)
+            assert trad["templates"], f"{trad_id} should ship at least one template"
+            for tmpl in trad["templates"]:
+                # A successful build validates trait names, ranges, and the
+                # "no Sphere exceeds Arete" constraint for the template file.
+                char = loader.load_character_from_template(
+                    "mage", tmpl["file"], identity_override={"name": "Test"}
+                )
+                assert char.identity["name"] == "Test"
+                assert char.identity["tradition"] == trad["name"]
+                assert char.get("Arete") >= 1
+                assert char.resources.has_resource("quintessence")


### PR DESCRIPTION
Closes #11.

Adds two new selectable factions to the Mage chargen config (`game/splats/mage/chargen.yaml`), each with appropriate affinity Spheres and working character templates.

## What's added

### Hollow Ones (quasi-Tradition)
- **Affinity Sphere: Entropy.** This matches the project's own author-guide example (`Entropy and Mind — find truth in decay and disillusion`), so the canon-eclectic Hollow Ones get a consistent default. Easy to retune to Spirit if you'd prefer the ghost-medium reading to lead.
- Templates:
  - **Gothic Poet** — Entropy/Mind, finds truth in decay and disillusion.
  - **Deathly Medium** — Entropy/Spirit, communes with the dead.

### Orphans / Disparates (unaffiliated)
- **Affinity Sphere: `Any`.** Orphans Awaken without a Tradition and pick their own affinity, so no single Sphere is fixed. The spheres screen renders this gracefully (`if len(affinity_sphere) > 0` shows the label; `trait_name == affinity_sphere` never falsely highlights a Sphere named "Any"). `free_sphere_dot` is `null`.
- Templates:
  - **Self-Taught Sorcerer** — Forces/Prime, raw magick reinvented alone.
  - **Intuitive Empath** — Mind/Life, an untrained psychic.

## Template balance
All four template files follow the existing `va_*` convention: Arete 3, **6 Sphere dots**, **7 Background dots**, every Sphere ≤ Arete, willpower 5. Each picks a concrete Sphere focus (the Orphan builds showcase the "any affinity" flexibility).

## Tests & docs
- Updated the traditions-count assertion in `tests/test_loader.py` (9 → 11).
- Added `TestHollowOnesAndOrphans`, which checks the factions and their affinities and **builds every referenced template** (a successful build validates trait names, ranges, and the "no Sphere exceeds Arete" constraint).
- Refreshed the author-guide "adding a new Tradition" example to use the not-included **Taftani** craft, since Hollow Ones now ships by default.

## Verification
- `python -m pytest -q` → **124 passed** (122 baseline + 2 new).
- Built all four templates through the real in-game `ChargenState` → `build_character` template flow; all valid (Σ6 Spheres, Σ7 Backgrounds, Arete 3).

## Note
The two new factions are data-driven and slot into the existing `traditions` list — no engine/screen code changes were needed; the identity picker and template-pick screen already iterate that list generically.

https://claude.ai/code/session_01XsCPZbFEYPRgxdfTdb3VMC

---
_Generated by [Claude Code](https://claude.ai/code/session_01XsCPZbFEYPRgxdfTdb3VMC)_