### PR TITLE
Add freebie cost validation tests (FreebieCalculator)

### DIFF
--- a/game/splats/mage/chargen.yaml
+++ b/game/splats/mage/chargen.yaml
@@ -8,6 +8,7 @@ modes:
     sphere_dots: 6
     background_dots: 7
     freebie_points: 15
+    max_flaw_points: 7    # Flaws grant at most 7 freebie points (M20 standard)
     starting_arete: 1
     starting_resonance: 1   # dots granted to the chosen Resonance type
     freebie_costs:

--- a/game/wod_core/chargen.py
+++ b/game/wod_core/chargen.py
@@ -187,6 +187,135 @@ class PointPool:
         self._allocations.clear()
 
 
+# M20 standard: a character may take at most 7 points of Flaws for freebies.
+MAX_FLAW_POINTS = 7
+
+# Maps a schema trait-category name to its key in the ``freebie_costs`` config.
+_FREEBIE_COST_KEYS = {
+    "attributes": "attribute",
+    "abilities": "ability",
+    "spheres": "sphere",
+    "backgrounds": "background",
+}
+
+# Per-category freebie costs (M20), used when a key is absent from config.
+_DEFAULT_FREEBIE_COSTS = {
+    "attribute": 5,
+    "ability": 2,
+    "sphere": 7,
+    "background": 1,
+    "willpower": 1,
+}
+
+
+def _entry_points(entry: dict) -> int:
+    """Point value of a Merit/Flaw entry (positive = Merit, negative = Flaw)."""
+    return entry.get("cost", entry.get("value", 0))
+
+
+class FreebieCalculator:
+    """Computes freebie-point costs and validates spending against the budget.
+
+    Pure calculator (no mutable allocation state): the current selections are
+    passed in to each method. Encapsulates the M20 freebie rules so the same
+    logic backs both the chargen UI and its tests:
+
+      * Trait dots cost a per-category rate read from ``freebie_costs``
+        (Attribute=5, Ability=2, Sphere=7, Background=1, Willpower=1).
+      * Merits cost their listed point value.
+      * Flaws grant freebie points equal to their value, capped in total at
+        ``max_flaw_points`` (7 by M20 standard).
+    """
+
+    def __init__(
+        self,
+        schema,
+        freebie_costs: dict | None = None,
+        base_points: int = 15,
+        max_flaw_points: int = MAX_FLAW_POINTS,
+    ):
+        self.schema = schema
+        self.costs = dict(_DEFAULT_FREEBIE_COSTS)
+        if freebie_costs:
+            self.costs.update(freebie_costs)
+        self.base_points = base_points
+        self.max_flaw_points = max_flaw_points
+
+    @classmethod
+    def from_config(cls, schema, mode_config: dict) -> "FreebieCalculator":
+        """Build a calculator from a chargen mode-config dict."""
+        return cls(
+            schema=schema,
+            freebie_costs=mode_config.get("freebie_costs"),
+            base_points=mode_config.get("freebie_points", 15),
+            max_flaw_points=mode_config.get("max_flaw_points", MAX_FLAW_POINTS),
+        )
+
+    # --- per-trait costs -------------------------------------------------
+
+    def cost_rate(self, trait_name: str) -> int:
+        """Freebie cost for a single dot of ``trait_name`` (0 if uncosted)."""
+        # Willpower is a resource, not a schema trait, so match it by name.
+        if trait_name.lower() == "willpower":
+            return self.costs.get("willpower", 0)
+        cat_name = self.schema.trait_lookup.get(trait_name, "") if self.schema else ""
+        cost_key = _FREEBIE_COST_KEYS.get(cat_name)
+        if cost_key is None:
+            return 0
+        return self.costs.get(cost_key, 0)
+
+    def trait_cost(self, trait_name: str, dots: int) -> int:
+        """Total freebie cost to add ``dots`` dots to ``trait_name``."""
+        if dots <= 0:
+            return 0
+        return dots * self.cost_rate(trait_name)
+
+    def traits_cost(self, trait_additions: dict) -> int:
+        """Total freebie cost across a ``{trait_name: dots}`` mapping."""
+        return sum(self.trait_cost(t, d) for t, d in trait_additions.items())
+
+    # --- merits ----------------------------------------------------------
+
+    @staticmethod
+    def merits_cost(merits: list) -> int:
+        """Total freebie cost of selected Merits (their listed values)."""
+        return sum(_entry_points(m) for m in merits)
+
+    # --- flaws -----------------------------------------------------------
+
+    @staticmethod
+    def raw_flaw_points(flaws: list) -> int:
+        """Sum of Flaw point values before applying the cap."""
+        return sum(abs(_entry_points(f)) for f in flaws)
+
+    def flaw_points(self, flaws: list) -> int:
+        """Freebie points granted by Flaws, capped at ``max_flaw_points``."""
+        return min(self.raw_flaw_points(flaws), self.max_flaw_points)
+
+    def can_add_flaw(self, current_flaws: list, flaw: dict) -> bool:
+        """Whether selecting ``flaw`` keeps total Flaw points within the cap."""
+        projected = self.raw_flaw_points(current_flaws) + abs(_entry_points(flaw))
+        return projected <= self.max_flaw_points
+
+    # --- budget ----------------------------------------------------------
+
+    def total_budget(self, flaws: list) -> int:
+        """Base freebies plus the (capped) points granted by Flaws."""
+        return self.base_points + self.flaw_points(flaws)
+
+    def total_spent(self, trait_additions: dict, merits: list) -> int:
+        """Freebies spent on trait additions and Merits."""
+        return self.traits_cost(trait_additions) + self.merits_cost(merits)
+
+    def remaining(self, trait_additions: dict, merits: list, flaws: list) -> int:
+        """Freebies left after spending (negative if overspent)."""
+        return self.total_budget(flaws) - self.total_spent(trait_additions, merits)
+
+    def is_valid(self, trait_additions: dict, merits: list, flaws: list) -> bool:
+        """True if spending does not exceed the available budget."""
+        return self.remaining(trait_additions, merits, flaws) >= 0
+
+
 def build_character(state: ChargenState) -> Character:
     """Convert a completed ChargenState into a Character object."""
     if state.mode == "template":

--- a/game/wod_screens/chargen.rpy
+++ b/game/wod_screens/chargen.rpy
@@ -946,8 +946,6 @@ screen chargen_freebies(state):
     modal True
 
     $ mode_config = state.config["modes"]["full"]
-    $ freebie_total = mode_config.get("freebie_points", 15)
-    $ freebie_costs = mode_config.get("freebie_costs", {})
     $ available_merits = state.config.get("merits", [])
     $ available_flaws = state.config.get("flaws", [])
     $ prev_data = state.data.get("freebies", {})
@@ -962,27 +960,16 @@ screen chargen_freebies(state):
                 selected_merits = list(prev_data.get("merits", []))
                 selected_flaws = list(prev_data.get("flaws", []))
 
-    # Calculate spent freebies
-    $ merit_cost = sum(m.get("cost", m.get("value", 0)) for m in selected_merits)
-    $ flaw_refund = sum(abs(f.get("cost", f.get("value", 0))) for f in selected_flaws)
-    $ trait_cost = 0
+    # Freebie math — single source of truth: wod_core.chargen.FreebieCalculator
     python:
-        trait_cost = 0
-        for tname, dots in trait_adds.items():
-            cat_name = state.schema.trait_lookup.get(tname, "")
-            cat = state.schema.categories.get(cat_name)
-            if cat_name == "attributes":
-                trait_cost += dots * freebie_costs.get("attribute", 5)
-            elif cat_name == "abilities":
-                trait_cost += dots * freebie_costs.get("ability", 2)
-            elif cat_name == "spheres":
-                trait_cost += dots * freebie_costs.get("sphere", 7)
-            elif cat_name == "backgrounds":
-                trait_cost += dots * freebie_costs.get("background", 1)
-
-    $ total_spent = trait_cost + merit_cost
-    $ total_budget = freebie_total + flaw_refund
-    $ remaining = total_budget - total_spent
+        from wod_core.chargen import FreebieCalculator
+        freebie_calc = FreebieCalculator.from_config(state.schema, mode_config)
+        merit_cost = freebie_calc.merits_cost(selected_merits)
+        flaw_refund = freebie_calc.flaw_points(selected_flaws)   # capped (max 7)
+        trait_cost = freebie_calc.traits_cost(trait_adds)
+        total_spent = merit_cost + trait_cost
+        total_budget = freebie_calc.total_budget(selected_flaws)
+        remaining = total_budget - total_spent
 
     frame:
         xfill True
@@ -1078,11 +1065,17 @@ screen chargen_freebies(state):
                                     else:
                                         $ new_flaw_entry = {"name": f_name, "type": "flaw", "cost": f_cost, "value": f_cost}
                                         $ new_flaws = list(selected_flaws) + [new_flaw_entry]
-                                        textbutton "[f_name] (Refund: +[f_refund]) - [f_desc]":
-                                            text_size 13
-                                            text_color "#888888"
-                                            text_hover_color "#ffffff"
-                                            action SetScreenVariable("selected_flaws", new_flaws)
+                                        if freebie_calc.can_add_flaw(selected_flaws, new_flaw_entry):
+                                            textbutton "[f_name] (Refund: +[f_refund]) - [f_desc]":
+                                                text_size 13
+                                                text_color "#888888"
+                                                text_hover_color "#ffffff"
+                                                action SetScreenVariable("selected_flaws", new_flaws)
+                                        else:
+                                            textbutton "[f_name] (Refund: +[f_refund]) — Flaw cap reached":
+                                                text_size 13
+                                                text_color "#555555"
+                                                sensitive False
 
                         null height 15
 

--- a/tests/test_chargen.py
+++ b/tests/test_chargen.py
@@ -5,6 +5,8 @@ import yaml
 from wod_core.chargen import (
     ChargenState,
     PointPool,
+    FreebieCalculator,
+    MAX_FLAW_POINTS,
     build_character,
     validate_priorities,
 )
@@ -34,6 +36,18 @@ _TEMPLATE_IDS = [
 def mage_splat():
     loader = SplatLoader(GAME_DIR)
     return loader.load_splat("mage")
+
+
+@pytest.fixture
+def full_mode_config(mage_splat):
+    """The 'full' chargen mode config (carries freebie costs/points)."""
+    return mage_splat.chargen_config["modes"]["full"]
+
+
+@pytest.fixture
+def freebie_calc(mage_splat, full_mode_config):
+    """FreebieCalculator built from the real Mage chargen config."""
+    return FreebieCalculator.from_config(mage_splat.schema, full_mode_config)
 
 
 class TestChargenState:
@@ -395,3 +409,231 @@ class TestTraditionTemplates:
                 assert mf["name"] in merit_names, f"unknown merit {mf['name']!r}"
             elif mf["type"] == "flaw":
                 assert mf["name"] in flaw_names, f"unknown flaw {mf['name']!r}"
+
+
+class TestFreebieCostConfig:
+    """The chargen config carries the documented M20 freebie costs."""
+
+    def test_per_category_costs_match_m20(self, full_mode_config):
+        costs = full_mode_config["freebie_costs"]
+        assert costs["attribute"] == 5
+        assert costs["ability"] == 2
+        assert costs["sphere"] == 7
+        assert costs["background"] == 1
+        assert costs["willpower"] == 1
+
+    def test_freebie_points_is_15(self, full_mode_config):
+        assert full_mode_config["freebie_points"] == 15
+
+    def test_max_flaw_points_is_7(self, full_mode_config):
+        assert full_mode_config["max_flaw_points"] == 7
+
+    def test_merits_have_positive_costs(self, mage_splat):
+        merits = mage_splat.chargen_config["merits"]
+        assert merits  # config defines at least one merit
+        for merit in merits:
+            assert merit["cost"] > 0, f"{merit['name']} should cost a positive value"
+
+    def test_flaws_have_negative_costs(self, mage_splat):
+        flaws = mage_splat.chargen_config["flaws"]
+        assert flaws
+        for flaw in flaws:
+            assert flaw["cost"] < 0, f"{flaw['name']} should have a negative cost"
+
+
+class TestFreebieCalculatorConstruction:
+    """from_config and default construction wire up the expected values."""
+
+    def test_from_config_reads_base_points(self, freebie_calc):
+        assert freebie_calc.base_points == 15
+
+    def test_from_config_reads_max_flaw_points(self, freebie_calc):
+        assert freebie_calc.max_flaw_points == 7
+
+    def test_default_max_flaw_points_constant(self):
+        assert MAX_FLAW_POINTS == 7
+
+    def test_defaults_when_no_config(self, mage_splat):
+        # With no freebie_costs supplied, the M20 defaults apply.
+        calc = FreebieCalculator(mage_splat.schema)
+        assert calc.trait_cost("Strength", 1) == 5
+        assert calc.trait_cost("Technology", 1) == 2
+        assert calc.trait_cost("Forces", 1) == 7
+        assert calc.trait_cost("Avatar", 1) == 1
+        assert calc.trait_cost("willpower", 1) == 1
+        assert calc.max_flaw_points == 7
+
+
+class TestFreebieTraitCosts:
+    """Per-category dot costs: Attribute=5, Ability=2, Sphere=7, etc."""
+
+    @pytest.mark.parametrize("trait,expected_rate", [
+        ("Strength", 5),       # attribute
+        ("Intelligence", 5),   # attribute
+        ("Technology", 2),     # ability (skill)
+        ("Occult", 2),         # ability (knowledge)
+        ("Forces", 7),         # sphere
+        ("Correspondence", 7), # sphere
+        ("Avatar", 1),         # background
+        ("Node", 1),           # background
+        ("willpower", 1),      # resource (matched by name)
+    ])
+    def test_cost_rate_per_category(self, freebie_calc, trait, expected_rate):
+        assert freebie_calc.cost_rate(trait) == expected_rate
+
+    def test_attribute_dot_costs_5(self, freebie_calc):
+        assert freebie_calc.trait_cost("Strength", 1) == 5
+
+    def test_attribute_multiple_dots(self, freebie_calc):
+        assert freebie_calc.trait_cost("Strength", 3) == 15
+
+    def test_ability_dot_costs_2(self, freebie_calc):
+        assert freebie_calc.trait_cost("Technology", 1) == 2
+        assert freebie_calc.trait_cost("Technology", 4) == 8
+
+    def test_sphere_dot_costs_7(self, freebie_calc):
+        assert freebie_calc.trait_cost("Forces", 1) == 7
+        assert freebie_calc.trait_cost("Forces", 2) == 14
+
+    def test_background_dot_costs_1(self, freebie_calc):
+        assert freebie_calc.trait_cost("Avatar", 1) == 1
+        assert freebie_calc.trait_cost("Avatar", 5) == 5
+
+    def test_willpower_dot_costs_1(self, freebie_calc):
+        # Willpower is a resource, not a schema trait — matched by name.
+        assert freebie_calc.trait_cost("willpower", 1) == 1
+        assert freebie_calc.trait_cost("willpower", 3) == 3
+
+    def test_zero_dots_cost_nothing(self, freebie_calc):
+        assert freebie_calc.trait_cost("Strength", 0) == 0
+
+    def test_negative_dots_cost_nothing(self, freebie_calc):
+        assert freebie_calc.trait_cost("Strength", -2) == 0
+
+    def test_uncosted_category_is_free(self, freebie_calc):
+        # Arete is a real trait but not a freebie-spendable category.
+        assert freebie_calc.cost_rate("Arete") == 0
+        assert freebie_calc.trait_cost("Arete", 3) == 0
+
+    def test_unknown_trait_is_free(self, freebie_calc):
+        assert freebie_calc.trait_cost("Nonexistent", 2) == 0
+
+    def test_traits_cost_sums_mixed_categories(self, freebie_calc):
+        additions = {"Strength": 1, "Technology": 2, "Forces": 1, "Avatar": 3}
+        # 1*5 + 2*2 + 1*7 + 3*1 = 19
+        assert freebie_calc.traits_cost(additions) == 19
+
+    def test_traits_cost_empty(self, freebie_calc):
+        assert freebie_calc.traits_cost({}) == 0
+
+
+class TestFreebieMerits:
+    """Merits cost their listed point value."""
+
+    def test_merit_cost_matches_listed_value(self, freebie_calc):
+        assert freebie_calc.merits_cost([{"name": "X", "cost": 3}]) == 3
+
+    def test_multiple_merits_sum(self, freebie_calc):
+        merits = [{"name": "A", "cost": 3}, {"name": "B", "cost": 5}]
+        assert freebie_calc.merits_cost(merits) == 8
+
+    def test_merit_uses_value_when_cost_absent(self, freebie_calc):
+        assert freebie_calc.merits_cost([{"name": "X", "value": 4}]) == 4
+
+    def test_no_merits_cost_nothing(self, freebie_calc):
+        assert freebie_calc.merits_cost([]) == 0
+
+    def test_config_merits_charged_listed_value(self, freebie_calc, mage_splat):
+        # Each Merit defined in the config is charged exactly its listed cost.
+        for merit in mage_splat.chargen_config["merits"]:
+            assert freebie_calc.merits_cost([merit]) == merit["cost"]
+
+
+class TestFreebieFlawCap:
+    """Flaws grant freebie points, capped at 7 (M20 standard)."""
+
+    def test_flaw_points_below_cap(self, freebie_calc):
+        assert freebie_calc.flaw_points([{"name": "Blind", "cost": -6}]) == 6
+
+    def test_flaw_points_exactly_at_cap(self, freebie_calc):
+        flaws = [{"name": "Blind", "cost": -6}, {"name": "Nightmares", "cost": -1}]
+        assert freebie_calc.flaw_points(flaws) == 7
+
+    def test_flaw_points_capped_above_seven(self, freebie_calc):
+        flaws = [{"name": "Blind", "cost": -6}, {"name": "Sphere Inept", "cost": -5}]
+        assert freebie_calc.raw_flaw_points(flaws) == 11
+        assert freebie_calc.flaw_points(flaws) == 7  # capped
+
+    def test_raw_flaw_points_uncapped(self, freebie_calc):
+        flaws = [{"cost": -6}, {"cost": -5}, {"cost": -1}]
+        assert freebie_calc.raw_flaw_points(flaws) == 12
+
+    def test_no_flaws_grant_nothing(self, freebie_calc):
+        assert freebie_calc.flaw_points([]) == 0
+        assert freebie_calc.raw_flaw_points([]) == 0
+
+    def test_can_add_flaw_within_cap(self, freebie_calc):
+        assert freebie_calc.can_add_flaw([{"cost": -6}], {"cost": -1}) is True
+
+    def test_can_add_flaw_exactly_filling_cap(self, freebie_calc):
+        assert freebie_calc.can_add_flaw([], {"cost": -7}) is True
+
+    def test_cannot_add_flaw_exceeding_cap(self, freebie_calc):
+        assert freebie_calc.can_add_flaw([{"cost": -6}], {"cost": -5}) is False
+
+    def test_cannot_add_flaw_when_already_at_cap(self, freebie_calc):
+        assert freebie_calc.can_add_flaw([{"cost": -7}], {"cost": -1}) is False
+
+    def test_cap_is_configurable(self, mage_splat):
+        calc = FreebieCalculator(mage_splat.schema, max_flaw_points=5)
+        assert calc.flaw_points([{"cost": -6}]) == 5
+
+
+class TestFreebieBudget:
+    """Budget, spending, remaining, and validity."""
+
+    def test_base_budget_no_flaws(self, freebie_calc):
+        assert freebie_calc.total_budget([]) == 15
+
+    def test_budget_includes_flaw_points(self, freebie_calc):
+        flaws = [{"cost": -6}, {"cost": -1}]
+        assert freebie_calc.total_budget(flaws) == 22  # 15 + 7
+
+    def test_budget_caps_flaw_contribution(self, freebie_calc):
+        # 11 raw flaw points only add the capped 7 to the budget.
+        flaws = [{"cost": -6}, {"cost": -5}]
+        assert freebie_calc.total_budget(flaws) == 22
+
+    def test_total_spent_traits_and_merits(self, freebie_calc):
+        spent = freebie_calc.total_spent({"Strength": 1}, [{"cost": 3}])
+        assert spent == 8  # 5 + 3
+
+    def test_remaining_within_budget(self, freebie_calc):
+        remaining = freebie_calc.remaining({"Strength": 1}, [{"cost": 3}], [])
+        assert remaining == 7  # 15 - 8
+
+    def test_remaining_with_flaw_refund(self, freebie_calc):
+        remaining = freebie_calc.remaining({}, [], [{"cost": -6}])
+        assert remaining == 21  # (15 + 6) - 0
+
+    def test_is_valid_within_budget(self, freebie_calc):
+        assert freebie_calc.is_valid({"Strength": 1}, [{"cost": 3}], []) is True
+
+    def test_is_valid_exactly_at_budget(self, freebie_calc):
+        # 3 sphere dots = 21; budget 15 + 6 flaw = 21 → exactly spent.
+        assert freebie_calc.remaining({"Forces": 3}, [], [{"cost": -6}]) == 0
+        assert freebie_calc.is_valid({"Forces": 3}, [], [{"cost": -6}]) is True
+
+    def test_overspend_is_invalid(self, freebie_calc):
+        # 3 sphere dots = 21 > 15 budget.
+        assert freebie_calc.remaining({"Forces": 3}, [], []) == -6
+        assert freebie_calc.is_valid({"Forces": 3}, [], []) is False
+
+    def test_flaws_beyond_cap_do_not_fund_overspend(self, freebie_calc):
+        # Selecting 11 raw flaw points only funds 7, so a 22-point spend fails
+        # if it relied on more than the cap.
+        flaws = [{"cost": -6}, {"cost": -5}]  # raw 11, capped 7 → budget 22
+        # Spend 4 attributes (20) + 1 background (1) = 21 ≤ 22 → valid
+        assert freebie_calc.is_valid({"Strength": 4, "Avatar": 1}, [], flaws) is True
+        # Spend 4 attributes (20) + 3 backgrounds (3) = 23 > 22 → invalid
+        assert freebie_calc.is_valid({"Strength": 4, "Avatar": 3}, [], flaws) is False

--- a/tests/test_chargen.py
+++ b/tests/test_chargen.py
@@ -348,11 +348,14 @@ class TestTraditionTemplates:
 
     def test_all_nine_traditions_present(self, mage_splat):
         names = {t["name"] for t in mage_splat.chargen_config["traditions"]}
-        assert names == {
+        # The nine core Traditions must always be offered. Quasi-Traditions
+        # (Hollow Ones) and unaffiliated mages (Orphans) may also appear, so
+        # this is a subset check rather than an exact-equality one.
+        assert {
             "Akashic Brotherhood", "Celestial Chorus", "Cult of Ecstasy",
             "Dreamspeakers", "Euthanatos", "Order of Hermes",
             "Sons of Ether", "Verbena", "Virtual Adepts",
-        }
+        } <= names
 
     def test_every_tradition_has_a_template(self, mage_splat):
         for trad in mage_splat.chargen_config["traditions"]:
@@ -380,12 +383,19 @@ class TestTraditionTemplates:
         # Resources are attached and usable.
         assert char.resources is not None
         assert char.resources.has_resource("willpower")
-        # The template leads with its Tradition's affinity Sphere.
-        assert char.get(tradition["affinity_sphere"]) >= 1
+        spheres = ("Correspondence", "Entropy", "Forces", "Life", "Matter",
+                   "Mind", "Prime", "Spirit", "Time")
+        affinity = tradition["affinity_sphere"]
+        if affinity in spheres:
+            # The template leads with its Tradition's affinity Sphere.
+            assert char.get(affinity) >= 1
+        else:
+            # Orphans/Disparates have no fixed affinity ("Any"); just require
+            # that the template invests in at least one Sphere.
+            assert any(char.get(s) >= 1 for s in spheres)
         # No Sphere exceeds Arete (engine enforces this on build; assert anyway).
         arete = char.get("Arete")
-        for sphere in ("Correspondence", "Entropy", "Forces", "Life", "Matter",
-                       "Mind", "Prime", "Spirit", "Time"):
+        for sphere in spheres:
             assert char.get(sphere) <= arete
 
     @pytest.mark.parametrize("tradition,template", _TEMPLATE_PARAMS, ids=_TEMPLATE_IDS)

--- a/tests/test_paradigm.py
+++ b/tests/test_paradigm.py
@@ -286,12 +286,23 @@ class TestRealMageParadigm:
         wod_core.init(GAME_DIR)
         wod_core.load_splat("mage")
 
+    # The nine core Traditions each channel a fixed paradigm. Hollow Ones and
+    # Orphans are deliberately unaffiliated — they pick their own focus — so
+    # they carry no fixed paradigm entry and are excluded here.
+    _CORE_TRADITIONS = frozenset({
+        "akashic_brotherhood", "celestial_chorus", "cult_of_ecstasy",
+        "dreamspeakers", "euthanatos", "order_of_hermes",
+        "sons_of_ether", "verbena", "virtual_adepts",
+    })
+
     def test_schema_has_paradigm(self):
         schema = wod_core.get_loader().loaded_splats["mage"].schema
         assert schema.paradigm is not None
-        # Every Tradition in chargen.yaml has a paradigm entry.
+        # Every core Tradition in chargen.yaml has a paradigm entry.
         chargen = wod_core.get_loader().loaded_splats["mage"].chargen_config
-        for trad in chargen["traditions"]:
+        core = [t for t in chargen["traditions"] if t["id"] in self._CORE_TRADITIONS]
+        assert len(core) == 9, "expected the nine core Traditions in chargen.yaml"
+        for trad in core:
             assert schema.paradigm.methods_for(trad["id"]), trad["id"]
 
     def test_demo_virtual_adept(self):


### PR DESCRIPTION
Closes #13.

## Summary

Adds test coverage for freebie spending, as flagged by the plan review. The freebie-cost math previously lived **only** inside the `chargen_freebies` Ren'Py screen, so it had no unit tests and two gaps versus the M20 design spec:

- **Flaw point cap (max 7) was never enforced** — the flaw picker granted unlimited freebie points.
- **Willpower additions cost nothing** — Willpower is a resource (not a schema trait), so the per-category cost loop silently skipped it even though `freebie_costs.willpower: 1` exists.

To make the logic testable (and fix those gaps), it's extracted into a pure `FreebieCalculator` in `wod_core/chargen.py`, which the screen now uses as the single source of truth.

## Changes

**Commit 1 — freebie validation (issue #13):**
- **`game/wod_core/chargen.py`** — new `FreebieCalculator` (+ `MAX_FLAW_POINTS`):
  - per-category dot costs (Attribute=5, Ability=2, Sphere=7, Background=1, Willpower=1)
  - Merit costs = their listed value
  - Flaw refund capped at `max_flaw_points` (7); `can_add_flaw()` guards selection
  - `total_budget` / `total_spent` / `remaining` / `is_valid` helpers
  - `from_config()` builds it from a chargen mode-config dict
- **`game/splats/mage/chargen.yaml`** — add `max_flaw_points: 7` (data-driven cap).
- **`game/wod_screens/chargen.rpy`** — `chargen_freebies` now calls `FreebieCalculator` instead of duplicating the math; the flaw picker disables Flaws that would exceed the cap.
- **`tests/test_chargen.py`** — 55 new tests across `TestFreebieCostConfig`, `TestFreebieCalculatorConstruction`, `TestFreebieTraitCosts`, `TestFreebieMerits`, `TestFreebieFlawCap`, and `TestFreebieBudget`.

**Commit 2 — fix pre-existing `main` CI breakage (test-only):**
`main`'s HEAD was already red: PR #37 (Hollow Ones & Orphans) added two non-core "traditions" to `chargen.yaml`, colliding with three tests from earlier PRs that assumed exactly the nine core Traditions. Since CI runs the whole suite, this failed on every PR. Scoped the three tests:
- `test_all_nine_traditions_present` → subset check (the 9 core must be present; quasi-Traditions may also appear)
- `test_template_builds[orphans-*]` → handle Orphans' `"Any"` affinity (they build fine; only the assertion was wrong)
- `test_schema_has_paradigm` → scope to the 9 core Traditions (Hollow Ones/Orphans are deliberately unaffiliated)

## Testing

`python -m pytest` → **327 passed** (272 from main's suite, now green, + 55 new freebie tests).

> Note: the Ren'Py screen edits were reviewed by hand and follow the existing screen patterns; `renpy lint` in CI covers them.

https://claude.ai/code/session_011xhGcgHmcg667EEmLWUFt8