### PR TITLE
Temporary stat modifiers (form-shifting, buffs)

### DIFF
--- a/docs/author-guide.md
+++ b/docs/author-guide.md
@@ -195,6 +195,38 @@ $ name = pc.identity["name"]
 $ tradition = pc.identity.get("tradition", "Unknown")
 ```
 
+### Temporary Modifiers (Form-Shifting & Buffs)
+
+Some powers change a character's traits temporarily — a Werewolf's Crinos form adds +4 Strength and +1 Stamina, a Demon's Apocalyptic Form grants bonuses, an Art might briefly sharpen a trait. The framework tracks these as **modifiers**, applied at runtime and keyed by a **source** name so you can remove them all at once.
+
+```renpy
+## Enter Crinos: one source, several traits
+$ pc.apply_modifier("Strength", 4, "Crinos")
+$ pc.apply_modifier("Stamina", 1, "Crinos")
+
+## ...now pc.get("Strength") reflects the bonus, and gates use it too
+if pc.gate("Strength", ">=", 7):
+    "The Crinos form tears through the door."
+
+## Shift back: remove everything from that source
+$ pc.remove_modifier("Crinos")
+```
+
+How modifiers behave:
+
+- **`pc.apply_modifier(trait, delta, source)`** adds a modifier. `delta` may be negative for penalties.
+- **`pc.remove_modifier(source)`** removes every modifier from that source (no-op if the source isn't active).
+- **`pc.clear_modifiers()`** removes all modifiers from every source.
+- **Modifiers stack.** Different sources add together, and repeated calls from the same source accumulate. To reset a source, remove it and re-apply.
+- **`pc.get(trait)`** returns the effective value (base + modifiers); **`pc.base(trait)`** returns the permanent value; **`pc.modifier_total(trait)`** returns just the sum of active modifiers.
+- **Gates and the bracket shorthand use the effective value** — a buffed character clears higher thresholds automatically.
+- **Buffs can exceed the normal maximum.** Crinos can push Strength past the human cap of 5; this is intentional.
+- **`pc.advance(trait)`** raises the *base* value, never the buffed one, so leveling up mid-buff behaves correctly.
+- **Trait caps use base values.** A temporary Arete buff won't let a Mage permanently raise a Sphere above their real Arete.
+- **Modifiers never persist in saves.** Reapply them from your game logic after a load (e.g. in a `label` that restores the active form).
+
+The character sheet shows base and modified ratings apart: buffed pips render green, penalised pips red, with a numeric annotation (`+4 = 7`), and an **Active Effects** panel lists each source.
+
 ---
 
 ## 4. Stat Gating
@@ -863,7 +895,7 @@ Test files:
 
 | File | Coverage |
 |------|----------|
-| `tests/test_engine.py` | Character creation, trait get/set/advance, range validation, constraints |
+| `tests/test_engine.py` | Character creation, trait get/set/advance, range validation, constraints, temporary modifiers |
 | `tests/test_gating.py` | Gate operators, merit checks, module-level gating |
 | `tests/test_resources.py` | Spend/gain, linked pools (Quintessence Wheel), pool caps |
 | `tests/test_chargen.py` | ChargenState, PointPool allocation, build_character |

--- a/game/wod_core/engine.py
+++ b/game/wod_core/engine.py
@@ -94,7 +94,9 @@ class MaxLinkedConstraint(Constraint):
         cat_name = schema.trait_lookup.get(trait_name)
         if cat_name != self.target_category:
             return True, ""
-        limit = character.get(self.limited_by)
+        # Compare against the base (permanent) value: a temporary buff to the
+        # limiting trait must not let a capped trait be permanently raised.
+        limit = character.base(self.limited_by)
         if value > limit:
             return False, (
                 f"{trait_name} cannot exceed {self.limited_by} "
@@ -118,6 +120,9 @@ class Character:
         self.merits_flaws = merits_flaws or []
         self.identity = identity or {}
         self.resources: ResourceManager | None = None  # set after creation
+        # Temporary trait modifiers, keyed by source name → {trait: delta}.
+        # Applied at runtime by game logic (form-shifting, buffs); never saved.
+        self.modifiers: dict[str, dict[str, int]] = {}
 
         # Initialize all traits to defaults
         for trait_name in schema.get_all_trait_names():
@@ -146,9 +151,40 @@ class Character:
                         raise ValueError(msg)
 
     def get(self, name: str) -> int:
+        """Effective trait value — base plus the sum of all active modifiers."""
+        if name not in self.traits:
+            raise KeyError(f"Unknown trait: {name!r}")
+        return self.traits[name] + self.modifier_total(name)
+
+    def base(self, name: str) -> int:
+        """Permanent trait value, ignoring any temporary modifiers."""
         if name not in self.traits:
             raise KeyError(f"Unknown trait: {name!r}")
         return self.traits[name]
+
+    def modifier_total(self, name: str) -> int:
+        """Sum of every active modifier on a trait, across all sources."""
+        return sum(source.get(name, 0) for source in self.modifiers.values())
+
+    def apply_modifier(self, name: str, delta: int, source: str) -> None:
+        """Add a temporary modifier to a trait, tracked by source name.
+
+        Modifiers stack: multiple sources add together, and repeated calls
+        from the same source accumulate. Remove them with remove_modifier().
+        Modifiers are runtime-only and never persist in saves.
+        """
+        if not self.schema.has_trait(name):
+            raise KeyError(f"Unknown trait: {name!r}")
+        source_mods = self.modifiers.setdefault(source, {})
+        source_mods[name] = source_mods.get(name, 0) + delta
+
+    def remove_modifier(self, source: str) -> None:
+        """Remove every modifier contributed by a source. No-op if absent."""
+        self.modifiers.pop(source, None)
+
+    def clear_modifiers(self) -> None:
+        """Remove all temporary modifiers from every source."""
+        self.modifiers.clear()
 
     def set(self, name: str, value: int) -> None:
         if not self.schema.has_trait(name):
@@ -165,7 +201,8 @@ class Character:
         self.traits[name] = value
 
     def advance(self, name: str) -> None:
-        self.set(name, self.get(name) + 1)
+        # Advance the permanent base value, not the temporarily-modified one.
+        self.set(name, self.base(name) + 1)
 
     def has(self, name: str) -> bool:
         return any(mf["name"] == name for mf in self.merits_flaws)
@@ -193,6 +230,8 @@ class Character:
     def __getstate__(self):
         """Exclude Schema object from pickle — store raw data instead."""
         state = self.__dict__.copy()
+        # Temporary modifiers are reapplied by game logic — never persisted.
+        state.pop("modifiers", None)
         # Schema is large and reconstructable — store the raw data instead
         if "schema" in state:
             schema = state.pop("schema")
@@ -228,6 +267,8 @@ class Character:
             self.schema = Schema(schema_data)
         else:
             self.schema = None
+        # Modifiers are never persisted; a loaded character always starts clean.
+        self.modifiers = {}
 
     def spend(self, name: str, amount: int) -> bool:
         if self.resources is None:

--- a/game/wod_screens/character_sheet.rpy
+++ b/game/wod_screens/character_sheet.rpy
@@ -53,6 +53,29 @@ screen character_sheet():
                     null width 0 xfill True
                     textbutton "\u2715" action Hide("character_sheet") text_size 24 text_color "#888888" text_hover_color "#ffffff"
 
+                # Active temporary effects (form-shifting, buffs) \u2014 itemized by source
+                if pc.modifiers:
+                    frame:
+                        background "#160f24"
+                        padding (12, 8, 12, 8)
+                        xfill True
+                        vbox:
+                            spacing 2
+                            text "Active Effects" size 14 color "#b8860b"
+                            $ effect_lines = []
+                            python:
+                                for _src, _mods in pc.modifiers.items():
+                                    _parts = []
+                                    for _trait, _delta in _mods.items():
+                                        if _delta == 0:
+                                            continue
+                                        _sign = "+" if _delta > 0 else "\u2212"
+                                        _parts.append("{} {}{}".format(_trait, _sign, abs(_delta)))
+                                    if _parts:
+                                        effect_lines.append("{}: {}".format(_src, ", ".join(_parts)))
+                            for line in effect_lines:
+                                text "[line]" size 13 color "#c0c0c0"
+
                 # Tab buttons
                 hbox:
                     spacing 10
@@ -91,35 +114,13 @@ screen character_sheet():
                                                 $ group_label = group_name.capitalize()
                                                 text "[group_label]" size 14 color "#888888" italic True
                                                 for trait_name in group_traits:
-                                                    $ val = pc.get(trait_name)
-                                                    $ max_val = cat.range[1]
-                                                    if val > 0 or cat.default > 0:
-                                                        hbox:
-                                                            spacing 10
-                                                            text trait_name size 14 color "#e0e0e0" min_width 200
-                                                            hbox:
-                                                                spacing 3
-                                                                for d in range(max_val):
-                                                                    if d < val:
-                                                                        text "\u25cf" size 14 color "#b8860b"
-                                                                    else:
-                                                                        text "\u25cb" size 14 color "#444444"
+                                                    if pc.base(trait_name) > 0 or pc.modifier_total(trait_name) != 0 or cat.default > 0:
+                                                        use trait_row(pc, trait_name, cat.range[1])
                                                 null height 5
                                         else:
                                             for trait_name in cat.trait_names:
-                                                $ val = pc.get(trait_name)
-                                                $ max_val = cat.range[1]
-                                                if val > 0 or cat.default > 0:
-                                                    hbox:
-                                                        spacing 10
-                                                        text trait_name size 14 color "#e0e0e0" min_width 200
-                                                        hbox:
-                                                            spacing 3
-                                                            for d in range(max_val):
-                                                                if d < val:
-                                                                    text "\u25cf" size 14 color "#b8860b"
-                                                                else:
-                                                                    text "\u25cb" size 14 color "#444444"
+                                                if pc.base(trait_name) > 0 or pc.modifier_total(trait_name) != 0 or cat.default > 0:
+                                                    use trait_row(pc, trait_name, cat.range[1])
                                         null height 10
                             else:
                                 # Merits & Resources tab
@@ -157,3 +158,37 @@ screen character_sheet():
 
     key "K_ESCAPE" action Hide("character_sheet")
     key "K_TAB" action Hide("character_sheet")
+
+
+## A single trait row: name, dot rating, and any active temporary modifier.
+## Base pips are gold; buffed pips green, penalised pips red — so the base and
+## the modified rating read apart at a glance. A numeric annotation ("+4 = 7")
+## spells out the modifier and effective total, which also covers buffs that
+## push a trait past its normal maximum (Crinos, Apocalyptic Form, etc.).
+screen trait_row(pc, trait_name, max_val):
+    $ base_val = pc.base(trait_name)
+    $ mod_total = pc.modifier_total(trait_name)
+    $ eff_val = base_val + mod_total
+    $ lo = min(base_val, eff_val)
+    $ hi = max(base_val, eff_val)
+    $ dot_count = max(max_val, hi)
+    hbox:
+        spacing 10
+        text trait_name size 14 color "#e0e0e0" min_width 200
+        hbox:
+            spacing 3
+            yalign 0.5
+            for d in range(dot_count):
+                if d < lo:
+                    text "●" size 14 color "#b8860b"
+                elif mod_total > 0 and d < hi:
+                    text "●" size 14 color "#6a9e6a"
+                elif mod_total < 0 and d < hi:
+                    text "●" size 14 color "#9e5a5a"
+                else:
+                    text "○" size 14 color "#444444"
+        if mod_total != 0:
+            $ mod_color = "#6a9e6a" if mod_total > 0 else "#9e5a5a"
+            $ mod_sign = "+" if mod_total > 0 else "−"
+            $ mod_label = "{}{} = {}".format(mod_sign, abs(mod_total), eff_val)
+            text "[mod_label]" size 13 color mod_color yalign 0.5

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -241,6 +241,128 @@ class TestCharacterGate:
             char.gate("Strength", "~", 3)
 
 
+class TestTraitModifiers:
+    """Test temporary stat modifiers (form-shifting, buffs) — issue #33."""
+
+    def test_apply_modifier_changes_get(self, mage_schema_data):
+        schema = Schema(mage_schema_data)
+        char = Character(schema, traits={"Strength": 3})
+        char.apply_modifier("Strength", 4, "Crinos")
+        assert char.get("Strength") == 7
+
+    def test_base_ignores_modifiers(self, mage_schema_data):
+        schema = Schema(mage_schema_data)
+        char = Character(schema, traits={"Strength": 3})
+        char.apply_modifier("Strength", 4, "Crinos")
+        assert char.base("Strength") == 3
+        assert char.get("Strength") == 7
+
+    def test_modifiers_from_different_sources_stack(self, mage_schema_data):
+        schema = Schema(mage_schema_data)
+        char = Character(schema, traits={"Strength": 2})
+        char.apply_modifier("Strength", 4, "Crinos")
+        char.apply_modifier("Strength", 1, "Rage Buff")
+        assert char.get("Strength") == 7
+        assert char.modifier_total("Strength") == 5
+
+    def test_repeated_modifier_from_same_source_accumulates(self, mage_schema_data):
+        schema = Schema(mage_schema_data)
+        char = Character(schema, traits={"Strength": 2})
+        char.apply_modifier("Strength", 1, "Buff")
+        char.apply_modifier("Strength", 2, "Buff")
+        assert char.get("Strength") == 5
+
+    def test_one_source_modifies_multiple_traits(self, mage_schema_data):
+        schema = Schema(mage_schema_data)
+        char = Character(schema, traits={"Strength": 3, "Stamina": 2})
+        char.apply_modifier("Strength", 4, "Crinos")
+        char.apply_modifier("Stamina", 1, "Crinos")
+        assert char.get("Strength") == 7
+        assert char.get("Stamina") == 3
+
+    def test_remove_modifier_by_source(self, mage_schema_data):
+        schema = Schema(mage_schema_data)
+        char = Character(schema, traits={"Strength": 3, "Stamina": 2})
+        char.apply_modifier("Strength", 4, "Crinos")
+        char.apply_modifier("Stamina", 1, "Crinos")
+        char.remove_modifier("Crinos")
+        assert char.get("Strength") == 3
+        assert char.get("Stamina") == 2
+
+    def test_remove_one_source_leaves_others(self, mage_schema_data):
+        schema = Schema(mage_schema_data)
+        char = Character(schema, traits={"Strength": 2})
+        char.apply_modifier("Strength", 4, "Crinos")
+        char.apply_modifier("Strength", 1, "Rage Buff")
+        char.remove_modifier("Crinos")
+        assert char.get("Strength") == 3
+
+    def test_remove_unknown_source_is_noop(self, mage_schema_data):
+        schema = Schema(mage_schema_data)
+        char = Character(schema, traits={"Strength": 3})
+        char.remove_modifier("Nonexistent")  # should not raise
+        assert char.get("Strength") == 3
+
+    def test_clear_modifiers(self, mage_schema_data):
+        schema = Schema(mage_schema_data)
+        char = Character(schema, traits={"Strength": 2})
+        char.apply_modifier("Strength", 4, "Crinos")
+        char.apply_modifier("Strength", 1, "Rage Buff")
+        char.clear_modifiers()
+        assert char.get("Strength") == 2
+        assert char.modifiers == {}
+
+    def test_modifier_can_exceed_normal_range(self, mage_schema_data):
+        # Supernatural forms intentionally push traits past the human maximum.
+        schema = Schema(mage_schema_data)
+        char = Character(schema, traits={"Strength": 5})
+        char.apply_modifier("Strength", 4, "Crinos")
+        assert char.get("Strength") == 9
+
+    def test_negative_modifier_penalty(self, mage_schema_data):
+        schema = Schema(mage_schema_data)
+        char = Character(schema, traits={"Strength": 4})
+        char.apply_modifier("Strength", -2, "Wounded")
+        assert char.get("Strength") == 2
+
+    def test_modifier_total_zero_when_unmodified(self, mage_schema_data):
+        schema = Schema(mage_schema_data)
+        char = Character(schema, traits={"Strength": 3})
+        assert char.modifier_total("Strength") == 0
+
+    def test_apply_modifier_unknown_trait_raises(self, mage_schema_data):
+        schema = Schema(mage_schema_data)
+        char = Character(schema)
+        with pytest.raises(KeyError, match="Unknown trait"):
+            char.apply_modifier("Nonexistent", 2, "Buff")
+
+    def test_gate_uses_modified_value(self, mage_schema_data):
+        schema = Schema(mage_schema_data)
+        char = Character(schema, traits={"Strength": 3})
+        assert char.gate("Strength", ">=", 5) is False
+        char.apply_modifier("Strength", 4, "Crinos")
+        assert char.gate("Strength", ">=", 5) is True
+        assert char.gate("Strength", ">=", 7) is True
+
+    def test_advance_uses_base_not_modified(self, mage_schema_data):
+        # Advancing a buffed trait must increment the base, not base+modifier.
+        schema = Schema(mage_schema_data)
+        char = Character(schema, traits={"Strength": 3})
+        char.apply_modifier("Strength", 1, "Buff")
+        char.advance("Strength")
+        assert char.base("Strength") == 4
+        assert char.get("Strength") == 5
+
+    def test_constraint_uses_base_not_modified(self, mage_schema_data):
+        # A temporary Arete buff must not permit permanently raising a Sphere.
+        schema = Schema(mage_schema_data)
+        char = Character(schema, traits={"Arete": 2, "Forces": 2})
+        char.apply_modifier("Arete", 3, "Time Magic")
+        assert char.get("Arete") == 5
+        with pytest.raises(ValueError, match="cannot exceed Arete"):
+            char.set("Forces", 3)
+
+
 class TestCategoryDefGroups:
     """Test that CategoryDef preserves group structure."""
 
@@ -307,3 +429,25 @@ class TestCharacterSerialization:
         assert restored.schema is not None
         assert restored.schema.has_trait("Strength")
         assert restored.gate("Strength", ">=", 3) is True
+
+    def test_modifiers_excluded_from_state(self, mage_schema_data):
+        schema = Schema(mage_schema_data)
+        char = Character(schema, traits={"Strength": 3})
+        char.apply_modifier("Strength", 4, "Crinos")
+
+        state = char.__getstate__()
+        assert "modifiers" not in state
+
+    def test_modifiers_do_not_persist_in_saves(self, mage_schema_data):
+        # Modifiers are runtime-only; a loaded character has its base values.
+        schema = Schema(mage_schema_data)
+        char = Character(schema, traits={"Strength": 3})
+        char.apply_modifier("Strength", 4, "Crinos")
+        assert char.get("Strength") == 7
+
+        restored = pickle.loads(pickle.dumps(char))
+        assert restored.modifiers == {}
+        assert restored.get("Strength") == 3
+        # Game logic can reapply the modifier after load.
+        restored.apply_modifier("Strength", 4, "Crinos")
+        assert restored.get("Strength") == 7

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -140,6 +140,52 @@ merits_flaws: []
         assert char.get("Forces") == 3
 
 
+    def test_temporary_modifier_buff_affects_gates_and_saves(self, tmp_path):
+        import pickle
+
+        char_yaml = tmp_path / "shifter.yaml"
+        char_yaml.write_text("""
+schema: mage
+template: default_mage
+character_type: pc
+identity:
+  name: "Buffed Mage"
+traits:
+  attributes:
+    Strength: 2
+    Stamina: 2
+  arete:
+    Arete: 3
+resources: {}
+merits_flaws: []
+""")
+        char = wod_core.load_character(str(char_yaml))
+        wod_core.set_active(char)
+
+        # Before any buff, a high threshold fails.
+        assert wod_core.gate("Strength", ">=", 5) is False
+
+        # A form grants bonuses from a single source.
+        char.apply_modifier("Strength", 4, "Crinos")
+        char.apply_modifier("Stamina", 1, "Crinos")
+
+        # Module-level gates (and the bracket shorthand that compiles to them)
+        # now see the effective value.
+        assert wod_core.gate("Strength", ">=", 5) is True
+        assert char.base("Strength") == 2  # permanent value untouched
+
+        # Shifting back removes the whole source.
+        char.remove_modifier("Crinos")
+        assert wod_core.gate("Strength", ">=", 5) is False
+        assert char.get("Stamina") == 2
+
+        # Modifiers are runtime-only: a save/load drops them.
+        char.apply_modifier("Strength", 4, "Crinos")
+        restored = pickle.loads(pickle.dumps(char))
+        assert restored.modifiers == {}
+        assert restored.get("Strength") == 2
+
+
 class TestSyntaxIntegration:
     """Test syntax compiler with realistic Ren'Py-like script fragments."""
 


### PR DESCRIPTION
Closes #33.

Adds a runtime modifier system so splats can temporarily change traits — Werewolf's Crinos form (+4 Strength, +1 Stamina), Demon's Apocalyptic Form, Changeling Arts, etc. Unblocks #27 (Werewolf) and #31 (Demon).

## Engine (`Character`)

- **`apply_modifier(trait, delta, source)` / `remove_modifier(source)` / `clear_modifiers()`** — modifiers are tracked by source name (`dict[source → {trait: delta}]`). They **stack**: different sources add together, and repeated calls from the same source accumulate. `delta` may be negative for penalties.
- **`get()` returns base + sum of active modifiers.** New **`base()`** returns the permanent value and **`modifier_total()`** returns just the delta.
- **`gate()` uses the modified value** automatically (it delegates to `get()`), so gated choices and the bracket shorthand respect buffs with no extra work.
- **Buffs may exceed the normal maximum** (Crinos pushes Strength past 5) — intentional.
- **Correctness guards:** `advance()` raises the *base* value, and `max_linked` constraints compare against base values, so a temporary Arete buff can't be exploited to permanently raise a Sphere.
- **Modifiers never persist in saves** — excluded from `__getstate__` and reset in `__setstate__`. Game logic reapplies them after load.

## Character sheet

- Reusable **`trait_row`** screen renders base pips gold, buffed pips green, penalised pips red, with a `+4 = 7` annotation (also covers ratings past the normal max).
- An **Active Effects** panel lists each active source and its per-trait deltas.

## Docs & tests

- New author-guide section: *Temporary Modifiers (Form-Shifting & Buffs)*.
- 19 new tests (engine, serialization, and an end-to-end form-shift scenario) covering stacking, removal, the base/effective split, gate behavior, constraints, advancement, and save exclusion.

All 141 tests pass locally (`python -m pytest tests/`).

## Notes for review

- `MaxLinkedConstraint.validate` now compares against `character.base(...)` instead of `get(...)`. With no modifiers active this is identical to the old behavior (all prior constraint tests still pass); it only differs when the limiting trait is temporarily buffed, where using the base value is the intended anti-exploit behavior.
- `.rpy` screens couldn't be compiled here (Ren'Py isn't in the env). The `trait_row` sub-screen and the `python:` block follow the same idioms already used elsewhere in `character_sheet.rpy`.

https://claude.ai/code/session_014QHBze57wSUQwbruHTjA3t

---
_Generated by [Claude Code](https://claude.ai/code/session_014QHBze57wSUQwbruHTjA3t)_