### PR TITLE
feat: add Resonance system (Dynamic/Entropic/Static)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ You write your story in Ren'Py. The framework handles character stats, resource 
 - **Data-driven splat packs** -- Mage: The Ascension ships built-in; extensible to Vampire, Werewolf, and custom splats.
 - **Resource pools with linked constraints** -- Quintessence and Paradox share a 20-point Wheel; gaining one reduces the other.
 - **Character creation** -- three modes: Full M20 (priority-based allocation), Simplified (flat dot pools), and Template (pick a pre-built archetype).
+- **Resonance** -- Dynamic/Entropic/Static traits color a mage's magick; gate story branches on them like any other stat.
 - **Persistent HUD** -- Quintessence/Paradox split bar, Willpower pips, Health track. Survives save/load.
 - **Tabbed character sheet** -- toggle with Tab. WoD-style dot display, organized by trait category.
 - **Gothic dark theme** -- serif typography (EB Garamond body, Cinzel headings), dark parchment palette.

--- a/docs/author-guide.md
+++ b/docs/author-guide.md
@@ -113,6 +113,7 @@ identity:
   name: "Elena Vasquez"
   tradition: "Virtual Adepts"
   essence: "Dynamic"
+  resonance: "Dynamic"
   nature: "Visionary"
   demeanor: "Architect"
 
@@ -139,6 +140,8 @@ traits:
     Correspondence: 1
   arete:
     Arete: 3
+  resonance:
+    Dynamic: 2
   backgrounds:
     Avatar: 3
     Node: 2
@@ -159,7 +162,7 @@ merits_flaws:
 |-------|----------|-------------|
 | `schema` | Yes | Which splat to use (e.g. `mage`). Must match a loaded splat ID. |
 | `identity` | No | Freeform dict: name, tradition, essence, nature, demeanor, etc. |
-| `traits` | No | Nested by category (attributes, abilities, spheres, arete, backgrounds). Omitted traits get the schema default. |
+| `traits` | No | Nested by category (attributes, abilities, spheres, arete, resonance, backgrounds). Omitted traits get the schema default. |
 | `resources` | No | Override starting resource values. Omitted resources get their YAML defaults. |
 | `merits_flaws` | No | List of `{name, type, value}` dicts. |
 
@@ -261,6 +264,27 @@ if pc.has("Avatar Companion"):
 ```
 
 `pc.has(name)` returns `True` if any entry in the character's `merits_flaws` list has a matching `name` field.
+
+### Gating on Resonance
+
+Resonance is the flavor a mage's magick leaves on reality. In M20 it comes in three types -- **Dynamic** (change, passion, chaos), **Entropic** (decay, fate, balance), and **Static** (stability, order, stasis). The framework models each type as an ordinary trait rated 0--5, so you gate on it exactly like a Sphere or Ability:
+
+```renpy
+if pc.gate("Dynamic", ">=", 2):
+    "Your restless, change-hungry Resonance floods the breach. The rigid Static ward sloughs apart."
+
+menu:
+    "Let the decay spread" if pc.gate("Entropic", ">=", 1):
+        jump entropic_path
+
+    "Hold the pattern steady" if pc.gate("Static", ">=", 1):
+        jump static_path
+
+    "Force the change" if pc.gate("Dynamic", ">=", 3):
+        jump dynamic_path
+```
+
+Because Resonance lives in `schema.yaml`, the bracket shorthand validates the type names just like any other trait: `[Static >= 2]` compiles to `wod_core.gate("Static", ">=", 2)`. A beginning mage created through chargen picks one type and starts with a single dot; you can raise it with `pc.advance("Dynamic")` during the story. See [Section 10](#10-data-files) for the `resonance` category definition.
 
 ### Module-Level Gating
 
@@ -473,7 +497,7 @@ elena "Welcome, [pc.identity['name']]."
 
 The traditional Mage: The Ascension creation process:
 
-1. **Identity** -- Name, Tradition, Nature, Demeanor, Essence.
+1. **Identity** -- Name, Tradition, Resonance, Nature, Demeanor, Essence. The chosen Resonance type starts at one dot.
 2. **Attribute Priority** -- Assign primary/secondary/tertiary to Physical/Social/Mental (pools of 7/5/3).
 3. **Attribute Allocation** -- Distribute dots within each priority tier.
 4. **Ability Priority** -- Same for Talents/Skills/Knowledges (pools of 13/9/5), max 3 per Ability at creation.
@@ -486,7 +510,7 @@ The traditional Mage: The Ascension creation process:
 
 A streamlined version for quicker setup:
 
-1. **Identity** -- Name, Tradition, Nature, Demeanor, Essence.
+1. **Identity** -- Name, Tradition, Resonance, Nature, Demeanor, Essence.
 2. **Attributes** -- 15 allocatable dots on top of the free 1 per Attribute (total 24).
 3. **Abilities** -- 27 allocatable dots.
 4. **Spheres** -- 6 Sphere dots.
@@ -706,6 +730,12 @@ trait_categories:
     default: 1
     range: [1, 10]
 
+  resonance:
+    display_name: "Resonance"
+    traits: [Dynamic, Entropic, Static]
+    default: 0
+    range: [0, 5]
+
 trait_constraints:
   - type: max_linked
     target_category: spheres
@@ -718,6 +748,8 @@ Key concepts:
 - **`traits`** is a flat list (used when grouping is not needed, e.g., Spheres).
 - **`trait_constraints`** enforce rules like "no Sphere can exceed Arete." The `max_linked` type caps all traits in `target_category` by the value of `limited_by`.
 - Trait names must be unique across all categories.
+
+The **`resonance`** category models M20 Resonance as three rated traits -- Dynamic, Entropic, and Static. Because it is an ordinary trait category, Resonance works with every framework feature automatically: gating (`[Static >= 2]`), the character sheet (it appears on the Spheres & Backgrounds tab via `manifest.yaml`), chargen (the identity step offers a Resonance picker and grants `starting_resonance` dots), and save/load. To rename or extend the types, edit this category or append to it with a [splat override](#11-customization) -- chargen reads the type list straight from the schema.
 
 ### resources.yaml
 

--- a/game/demo/elena.yaml
+++ b/game/demo/elena.yaml
@@ -1,5 +1,6 @@
 # Demo character: Elena Vasquez, Virtual Adept
 # Forces 3, Prime 2, Technology 3, Awareness 2 — all demo branches are reachable.
+# Dynamic 2 Resonance contrasts with the Technocratic ward's Static Pattern.
 schema: mage
 template: default_mage
 character_type: pc
@@ -8,6 +9,7 @@ identity:
   name: "Elena Vasquez"
   tradition: "Virtual Adepts"
   essence: "Dynamic"
+  resonance: "Dynamic"
   nature: "Visionary"
   demeanor: "Architect"
 
@@ -34,6 +36,8 @@ traits:
     Correspondence: 1
   arete:
     Arete: 3
+  resonance:
+    Dynamic: 2
   backgrounds:
     Avatar: 3
     Node: 2

--- a/game/script.rpy
+++ b/game/script.rpy
@@ -52,6 +52,10 @@ label analyze_ward:
 
         if pc.gate("Forces", ">=", 3):
             "Your understanding of Forces lets you unravel the energy matrix cleanly."
+
+            if pc.gate("Dynamic", ">=", 2):
+                "Your own Dynamic Resonance — restless, hungry for change — floods the breach. The ward's rigid Static Pattern cannot hold against so much momentum, and it sloughs apart faster than it has any right to."
+
             "But the Consensus pushes back. The ward was {i}expected{/i} to be there."
             $ pc.gain("paradox", 2)
             "You feel Paradox settle into your Pattern like static on a screen."
@@ -138,11 +142,13 @@ label epilogue:
     "  - Linked pool constraints (Paradox gain)"
     "  - Outcome branching based on stat levels"
     "  - Mid-story stat advancement (Awareness)"
+    "  - Resonance-flavored branching (Dynamic vs. Static)"
 
     if pc is not None:
         "Final character state:"
         "  Quintessence: [pc.resources.current('quintessence')]"
         "  Paradox: [pc.resources.current('paradox')]"
         "  Awareness: [pc.get('Awareness')]"
+        "  Dynamic Resonance: [pc.get('Dynamic')]"
 
     return

--- a/game/splats/mage/chargen.yaml
+++ b/game/splats/mage/chargen.yaml
@@ -9,6 +9,7 @@ modes:
     background_dots: 7
     freebie_points: 15
     starting_arete: 1
+    starting_resonance: 1   # dots granted to the chosen Resonance type
     freebie_costs:
       attribute: 5
       ability: 2
@@ -23,6 +24,7 @@ modes:
     ability_dots: 27     # allocatable dots (Abilities start at 0)
     sphere_dots: 6
     starting_arete: 1
+    starting_resonance: 1
 
   template:
     steps: [identity, template_pick, review]

--- a/game/splats/mage/manifest.yaml
+++ b/game/splats/mage/manifest.yaml
@@ -24,6 +24,6 @@ splat:
       - name: "Attributes & Abilities"
         categories: [attributes, abilities]
       - name: "Spheres & Backgrounds"
-        categories: [arete, spheres, backgrounds]
+        categories: [arete, spheres, resonance, backgrounds]
       - name: "Merits & Resources"
         categories: []

--- a/game/splats/mage/schema.yaml
+++ b/game/splats/mage/schema.yaml
@@ -89,6 +89,19 @@ trait_categories:
     default: 0
     range: [0, 5]
 
+  # Resonance — the flavor a mage's magick leaves on reality (M20).
+  # Every act of magick carries one of three Resonance types. Rated 0–5;
+  # a beginning mage typically has a single dot. Gate on these like any
+  # other trait, e.g. [Static >= 2] or pc.gate("Dynamic", ">=", 1).
+  resonance:
+    display_name: "Resonance"
+    traits:
+      - Dynamic
+      - Entropic
+      - Static
+    default: 0
+    range: [0, 5]
+
 trait_constraints:
   - type: max_linked
     target_category: spheres

--- a/game/splats/mage/templates/archmage.yaml
+++ b/game/splats/mage/templates/archmage.yaml
@@ -5,3 +5,5 @@ overrides:
       range: [0, 10]
     arete:
       range: [1, 10]
+    resonance:
+      range: [0, 10]

--- a/game/splats/mage/templates/default_mage.yaml
+++ b/game/splats/mage/templates/default_mage.yaml
@@ -6,6 +6,7 @@ identity:
   name: ""
   tradition: ""
   essence: ""
+  resonance: ""
   nature: ""
   demeanor: ""
 
@@ -24,6 +25,7 @@ traits:
   spheres: {}
   arete:
     Arete: 1
+  resonance: {}
   backgrounds: {}
 
 resources:

--- a/game/splats/mage/templates/va_code_witch.yaml
+++ b/game/splats/mage/templates/va_code_witch.yaml
@@ -5,6 +5,7 @@ identity:
   name: ""
   tradition: "Virtual Adepts"
   essence: "Dynamic"
+  resonance: "Dynamic"
   nature: "Visionary"
   demeanor: "Architect"
 traits:
@@ -32,6 +33,8 @@ traits:
     Forces: 1
   arete:
     Arete: 3
+  resonance:
+    Dynamic: 2
   backgrounds:
     Avatar: 2
     Resources: 2

--- a/game/splats/mage/templates/va_reality_hacker.yaml
+++ b/game/splats/mage/templates/va_reality_hacker.yaml
@@ -5,6 +5,7 @@ identity:
   name: ""
   tradition: "Virtual Adepts"
   essence: "Dynamic"
+  resonance: "Dynamic"
   nature: "Rebel"
   demeanor: "Thrill-Seeker"
 traits:
@@ -32,6 +33,8 @@ traits:
     Prime: 1
   arete:
     Arete: 3
+  resonance:
+    Dynamic: 1
   backgrounds:
     Avatar: 3
     Node: 2

--- a/game/wod_core/chargen.py
+++ b/game/wod_core/chargen.py
@@ -68,6 +68,15 @@ class ChargenState:
     def get_essences(self) -> list[str]:
         return self.config.get("essences", [])
 
+    def get_resonance_types(self) -> list[str]:
+        """Resonance types (Dynamic/Entropic/Static), read from the schema.
+
+        The resonance category in schema.yaml is the single source of truth,
+        so authors who add or rename types there get them in chargen for free.
+        """
+        cat = self.schema.categories.get("resonance")
+        return list(cat.trait_names) if cat is not None else []
+
 
 class PointPool:
     """Tracks dot allocation within a budget."""
@@ -151,6 +160,17 @@ def _build_from_allocation(state: ChargenState) -> Character:
                 starting_arete = t["starting_arete"]
             break
     flat_traits["Arete"] = starting_arete
+
+    # Apply the starting Resonance dot from the identity pick. In M20 a
+    # beginning mage has a single dot of Resonance reflecting the flavor of
+    # her magick; the player picks the type (Dynamic/Entropic/Static) on the
+    # identity screen. Picking nothing simply leaves Resonance at 0.
+    resonance_type = identity.get("resonance", "")
+    if resonance_type and state.schema.has_trait(resonance_type):
+        starting_resonance = mode_config.get("starting_resonance", 1)
+        flat_traits[resonance_type] = max(
+            flat_traits.get(resonance_type, 0), starting_resonance
+        )
 
     # Apply sphere and background allocations
     sb_data = state.data.get("spheres_backgrounds", state.data.get("spheres", {}))

--- a/game/wod_screens/chargen.rpy
+++ b/game/wod_screens/chargen.rpy
@@ -53,11 +53,16 @@ screen chargen_identity(state):
     default selected_essence = state.data.get("identity", {}).get("essence", "")
     default selected_nature = state.data.get("identity", {}).get("nature", "")
     default selected_demeanor = state.data.get("identity", {}).get("demeanor", "")
+    default selected_resonance = state.data.get("identity", {}).get("resonance", "")
 
     $ traditions = state.get_traditions()
     $ archetypes = state.get_archetypes()
     $ essences = state.get_essences()
+    $ resonance_types = state.get_resonance_types()
     $ is_full = (state.mode == "full")
+    # Resonance is a real (gateable) trait, so offer it in full and simplified
+    # creation. Template mode skips it — the template file sets Resonance.
+    $ show_resonance = (state.mode != "template")
 
     # Check if we can proceed
     $ can_proceed = len(name_input) > 0 and len(selected_tradition) > 0
@@ -123,6 +128,22 @@ screen chargen_identity(state):
                                         text_hover_color "#ffffff"
                                         action SetScreenVariable("selected_tradition", trad_name)
 
+                        if show_resonance and resonance_types:
+                            null height 10
+
+                            # Resonance picker — the flavor of the mage's magick
+                            text "Resonance:" size 16 color "#e0e0e0"
+                            text "The signature your magick leaves on reality. Begins at one dot." size 12 color "#888888"
+                            hbox:
+                                spacing 15
+                                for rtype in resonance_types:
+                                    $ res_color = "#c9a96e" if selected_resonance == rtype else "#888888"
+                                    textbutton "[rtype]":
+                                        text_size 14
+                                        text_color res_color
+                                        text_hover_color "#ffffff"
+                                        action SetScreenVariable("selected_resonance", rtype)
+
                         if is_full:
                             null height 10
 
@@ -179,7 +200,7 @@ screen chargen_identity(state):
                         null height 20
 
                         if can_proceed:
-                            $ next_result = {"action": "next", "name": name_input, "tradition": selected_tradition, "essence": selected_essence, "nature": selected_nature, "demeanor": selected_demeanor}
+                            $ next_result = {"action": "next", "name": name_input, "tradition": selected_tradition, "essence": selected_essence, "nature": selected_nature, "demeanor": selected_demeanor, "resonance": selected_resonance}
                             textbutton "Next Step >>":
                                 text_size 18
                                 text_color "#c9a96e"
@@ -1085,6 +1106,7 @@ screen chargen_review(state):
     $ essence = identity.get("essence", "")
     $ nature = identity.get("nature", "")
     $ demeanor = identity.get("demeanor", "")
+    $ resonance = identity.get("resonance", "")
 
     # Gather trait data depending on mode
     $ attr_data = state.data.get("attribute_allocate", state.data.get("attributes", {}))
@@ -1129,6 +1151,8 @@ screen chargen_review(state):
                             text "Tradition: [tradition]" size 14 color "#e0e0e0"
                         if len(essence) > 0:
                             text "Essence: [essence]" size 14 color "#e0e0e0"
+                        if len(resonance) > 0:
+                            text "Resonance: [resonance]" size 14 color "#e0e0e0"
                         if len(nature) > 0:
                             text "Nature: [nature] / Demeanor: [demeanor]" size 14 color "#e0e0e0"
 

--- a/tests/test_chargen.py
+++ b/tests/test_chargen.py
@@ -169,3 +169,67 @@ class TestBuildCharacter:
         assert char.identity["name"] == "Elena"
         assert char.get("Correspondence") == 3  # from template
         assert char.resources is not None
+
+
+class TestResonance:
+    """Test the Resonance system (Dynamic/Entropic/Static)."""
+
+    def test_resonance_types_from_schema(self, mage_splat):
+        state = ChargenState("mage", "full", mage_splat.schema, mage_splat.chargen_config, mage_splat)
+        assert state.get_resonance_types() == ["Dynamic", "Entropic", "Static"]
+
+    def test_full_build_grants_starting_resonance(self, mage_splat):
+        state = ChargenState("mage", "full", mage_splat.schema, mage_splat.chargen_config, mage_splat)
+        state.save_step("identity", {
+            "name": "Resonant Mage",
+            "tradition": "Verbena",
+            "resonance": "Dynamic",
+        })
+        state.save_step("attribute_allocate", {
+            "Strength": 2, "Dexterity": 2, "Stamina": 2,
+            "Charisma": 2, "Manipulation": 2, "Appearance": 2,
+            "Perception": 2, "Intelligence": 2, "Wits": 2,
+        })
+
+        char = build_character(state)
+
+        # Chosen type gets the starting dot; the others stay at 0.
+        assert char.get("Dynamic") == 1
+        assert char.get("Entropic") == 0
+        assert char.get("Static") == 0
+
+    def test_simplified_build_grants_starting_resonance(self, mage_splat):
+        state = ChargenState("mage", "simplified", mage_splat.schema, mage_splat.chargen_config, mage_splat)
+        state.save_step("identity", {
+            "name": "Quick Mage",
+            "tradition": "Euthanatos",
+            "resonance": "Entropic",
+        })
+
+        char = build_character(state)
+
+        assert char.get("Entropic") == 1
+        assert char.get("Dynamic") == 0
+
+    def test_build_without_resonance_pick_leaves_zero(self, mage_splat):
+        state = ChargenState("mage", "full", mage_splat.schema, mage_splat.chargen_config, mage_splat)
+        state.save_step("identity", {"name": "Plain Mage", "tradition": "Order of Hermes"})
+
+        char = build_character(state)
+
+        assert char.get("Dynamic") == 0
+        assert char.get("Entropic") == 0
+        assert char.get("Static") == 0
+
+    def test_template_build_carries_resonance(self, mage_splat):
+        state = ChargenState("mage", "template", mage_splat.schema, mage_splat.chargen_config, mage_splat)
+        state.save_step("identity", {"name": "Net Runner"})
+        state.save_step("template_pick", {
+            "tradition": "virtual_adepts",
+            "template_file": "templates/va_code_witch.yaml",
+        })
+
+        char = build_character(state)
+
+        # va_code_witch.yaml defines Dynamic: 2.
+        assert char.get("Dynamic") == 2

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -29,6 +29,8 @@ class TestMageIntegration:
         assert len(abilities.trait_names) == 33
         spheres = schema.categories["spheres"]
         assert len(spheres.trait_names) == 9
+        resonance = schema.categories["resonance"]
+        assert resonance.trait_names == ["Dynamic", "Entropic", "Static"]
 
     def test_create_character_and_gate(self, tmp_path):
         char_yaml = tmp_path / "elena.yaml"
@@ -81,6 +83,38 @@ merits_flaws:
 
         assert wod_core.has("Avatar Companion") is True
         assert wod_core.has("Nonexistent") is False
+
+    def test_resonance_loads_and_gates(self, tmp_path):
+        char_yaml = tmp_path / "resonant.yaml"
+        char_yaml.write_text("""
+schema: mage
+template: default_mage
+character_type: pc
+identity:
+  name: "Resonant Mage"
+  resonance: "Dynamic"
+traits:
+  arete:
+    Arete: 3
+  spheres:
+    Forces: 2
+  resonance:
+    Dynamic: 3
+    Static: 1
+resources: {}
+merits_flaws: []
+""")
+        char = wod_core.load_character(str(char_yaml))
+        wod_core.set_active(char)
+
+        assert char.get("Dynamic") == 3
+        assert char.get("Static") == 1
+        assert char.get("Entropic") == 0  # defaulted
+
+        assert wod_core.gate("Dynamic", ">=", 2) is True
+        assert wod_core.gate("Dynamic", ">=", 4) is False
+        assert wod_core.gate("Static", "<=", 1) is True
+        assert wod_core.gate("Entropic", "==", 0) is True
 
     def test_resource_spending_and_linked_pools(self, tmp_path):
         char_yaml = tmp_path / "mage.yaml"

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -22,6 +22,18 @@ class TestSplatLoader:
         assert splat.schema.has_trait("Arete")
         assert splat.schema.get_range("Strength") == (1, 5)
 
+    def test_load_splat_resonance_category(self):
+        loader = SplatLoader(GAME_DIR)
+        splat = loader.load_splat("mage")
+        schema = splat.schema
+        # The three M20 Resonance types are gateable traits.
+        for rtype in ("Dynamic", "Entropic", "Static"):
+            assert schema.has_trait(rtype)
+            assert schema.trait_lookup[rtype] == "resonance"
+            assert schema.get_range(rtype) == (0, 5)
+            assert schema.get_default(rtype) == 0
+        assert schema.categories["resonance"].display_name == "Resonance"
+
     def test_load_splat_resources(self):
         loader = SplatLoader(GAME_DIR)
         splat = loader.load_splat("mage")


### PR DESCRIPTION
Closes #21.

## What

Adds M20 **Resonance** — the flavor a mage's magick leaves on reality — as a **data-driven trait category** (the first option the issue suggested). The three types **Dynamic / Entropic / Static** become traits rated 0–5 in the Mage schema.

Modeling Resonance as an ordinary trait category means it works with every existing framework feature for free, with almost no engine code:

- **Gating** — `pc.gate("Dynamic", ">=", 2)` and bracket shorthand `[Static >= 2]`; the shorthand validator recognizes the type names because they live in `schema.yaml`.
- **Character sheet** — surfaced on the "Spheres & Backgrounds" tab via `manifest.yaml`; renders with the usual dot display.
- **Chargen** — the identity step gains a Resonance picker (mirroring Essence); a beginning mage picks one type and starts with `starting_resonance` dots (default 1, M20-accurate). Read straight from the schema, so it stays the single source of truth.
- **Save/load** — pickles like any other trait (verified by round-trip).

## Changes

| Area | Change |
|------|--------|
| `schema.yaml` | New `resonance` category: `[Dynamic, Entropic, Static]`, range 0–5, default 0 |
| `manifest.yaml` | Resonance added to the character-sheet tab |
| `chargen.yaml` / `chargen.py` | `starting_resonance` config; `get_resonance_types()`; starting dot applied in `build_character` |
| `chargen.rpy` | Resonance picker on the identity screen (full + simplified) + review line |
| templates / `elena.yaml` | Thematically apt Resonance (Virtual Adepts → Dynamic); archmage extends range to 0–10 |
| `script.rpy` | Demo gains a `Dynamic`-vs-`Static` gated beat |
| docs | Author guide (gating, chargen, schema reference) + README feature bullet |

## Design notes

I chose the **three types as rated traits** rather than M20's open-ended descriptive words because gating — the framework's core mechanic — wants stable, authorable identifiers (`[Static >= 2]`) rather than per-character adjectives. Authors who want to rename or extend the types can edit the category or use a splat override; chargen picks them up automatically.

## Testing

`pytest` — **129 passed** (122 baseline + 7 new across `test_loader`, `test_integration`, `test_chargen`): schema shape, end-to-end gating, chargen build (full/simplified/none), and template carry-through. Also manually exercised the full data path (splat + demo + every template load, pickle round-trip, bracket-shorthand validation).

> Note: Ren'Py `lint` could not be run in this environment, so the `.rpy` screen edits were reviewed by hand — they mirror the existing Essence picker's structure and indentation exactly, and contain no tabs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E43BosgEArF3qptcpqwZT2)_