### PR TITLE
Paradigm/Focus gating for Tradition-appropriate casting methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ You write your story in Ren'Py. The framework handles character stats, resource 
 ## Features
 
 - **Deterministic stat gating** -- no dice rolls. Stats unlock menu choices and affect story outcomes.
+- **Paradigm/Focus gating** -- optional per-Tradition casting methods. A Virtual Adept can cast through code but not prayer; gate choices on paradigm as well as stats.
 - **Data-driven splat packs** -- Mage: The Ascension ships built-in; extensible to Vampire, Werewolf, and custom splats.
 - **Resource pools with linked constraints** -- Quintessence and Paradox share a 20-point Wheel; gaining one reduces the other.
 - **Character creation** -- three modes: Full M20 (priority-based allocation), Simplified (flat dot pools), and Template (pick a pre-built archetype).
@@ -106,7 +107,7 @@ Run the test suite:
 pytest
 ```
 
-The test suite covers the core engine (`test_engine.py`), stat gating (`test_gating.py`), resource pools (`test_resources.py`), character creation (`test_chargen.py`), bracket syntax compilation (`test_syntax.py`), YAML loading (`test_loader.py`), and end-to-end integration (`test_integration.py`).
+The test suite covers the core engine (`test_engine.py`), stat gating (`test_gating.py`), paradigm/Focus gating (`test_paradigm.py`), resource pools (`test_resources.py`), character creation (`test_chargen.py`), bracket syntax compilation (`test_syntax.py`), YAML loading (`test_loader.py`), and end-to-end integration (`test_integration.py`).
 
 ### Engine Architecture
 

--- a/docs/author-guide.md
+++ b/docs/author-guide.md
@@ -332,6 +332,47 @@ if wod_core.has("Avatar Companion"):
 
 These delegate to whichever character was last set as active.
 
+### Paradigm & Focus Gating (Optional)
+
+Stats are not the only thing that should decide whether a choice is available. In *Mage*, a character's **paradigm** — their model of how reality works — and their **Focus** determine *how* they can work magick. A Virtual Adept rewrites reality through code and hypertech; she would never cast through prayer. A Celestial Chorister is the reverse.
+
+The framework lets a splat declare paradigm-appropriate **methods** per Tradition. Authors then gate choices on those methods, in addition to stats:
+
+```renpy
+if pc.can_use("code"):
+    "You open a console only you can see and rewrite the ward's parameters."
+
+menu:
+    "Rewrite the ward's source" if pc.can_use("code"):
+        jump rewrite_code
+
+    "Pray for a way through" if pc.can_use("prayer"):
+        jump pray
+
+    "Walk away":
+        jump leave
+```
+
+`pc.can_use(method)` returns `True` if the character's Tradition (read from `identity["tradition"]`) permits that casting method. A module-level `wod_core.can_use(method)` is also available after `set_active()`.
+
+The system is **opt-in and permissive**: if a splat defines no paradigm, `can_use()` returns `True` for everything, so nothing is restricted and existing games are unaffected. A Tradition that has no declared method list (and no `default`) cannot use any specific method.
+
+Methods are defined in the splat's `schema.yaml` — see [Defining a Paradigm](#defining-a-paradigm). For the bracket shorthand equivalent, see [`[via method]`](#5-bracket-shorthand).
+
+The Mage splat ships with this paradigm:
+
+| Tradition | Methods |
+|-----------|---------|
+| Akashic Brotherhood | meditation, martial_arts |
+| Celestial Chorus | prayer, art |
+| Cult of Ecstasy | art, dreaming |
+| Dreamspeakers | spirit_speech, dreaming |
+| Euthanatos | death_work, meditation |
+| Order of Hermes | ritual |
+| Sons of Ether | science |
+| Verbena | blood, herbalism, ritual |
+| Virtual Adepts | code, science |
+
 ### Outcome Branching
 
 Gate checks are not limited to menu choices. Use them anywhere for branching:
@@ -368,6 +409,9 @@ For authors who prefer a more concise syntax, the framework includes a pre-proce
 
 "Reject the dark path" [!Sphere Inept]:
     jump reject
+
+"Rewrite the ward's source" [via code]:
+    jump rewrite_code
 ```
 
 ```renpy
@@ -380,6 +424,9 @@ For authors who prefer a more concise syntax, the framework includes a pre-proce
 
 "Reject the dark path" if not wod_core.has("Sphere Inept"):
     jump reject
+
+"Rewrite the ward's source" if wod_core.can_use("code"):
+    jump rewrite_code
 ```
 
 ### Rules
@@ -387,6 +434,7 @@ For authors who prefer a more concise syntax, the framework includes a pre-proce
 - `[Trait >= N]` becomes `wod_core.gate("Trait", ">=", N)` -- any comparison operator works.
 - `[Merit Name]` (no operator) becomes `wod_core.has("Merit Name")`.
 - `[!Flaw Name]` (leading `!`) becomes `not wod_core.has("Flaw Name")`.
+- `[via method]` becomes `wod_core.can_use("method")` -- paradigm/Focus gating (see [Paradigm & Focus Gating](#paradigm--focus-gating-optional)). `[!via method]` negates it.
 - Multiple conditions separated by commas are joined with `and`.
 
 ### Running the Pre-Processor
@@ -783,6 +831,28 @@ Key concepts:
 
 The **`resonance`** category models M20 Resonance as three rated traits -- Dynamic, Entropic, and Static. Because it is an ordinary trait category, Resonance works with every framework feature automatically: gating (`[Static >= 2]`), the character sheet (it appears on the Spheres & Backgrounds tab via `manifest.yaml`), chargen (the identity step offers a Resonance picker and grants `starting_resonance` dots), and save/load. To rename or extend the types, edit this category or append to it with a [splat override](#11-customization) -- chargen reads the type list straight from the schema.
 
+#### Defining a Paradigm
+
+An optional `paradigm` block declares the casting **methods** each Tradition may use, powering [Paradigm & Focus Gating](#paradigm--focus-gating-optional). It lives alongside `trait_categories` in `schema.yaml`:
+
+```yaml
+paradigm:
+  methods:                        # registry: method id -> display name
+    code: "Cybernetics & Code"
+    prayer: "Prayer & Faith"
+    ritual: "High Ritual Magick"
+  traditions:                     # per-Tradition allow-lists
+    virtual_adepts: [code, science]
+    celestial_chorus: [prayer, art]
+    default: [code]               # optional: fallback for unlisted Traditions
+```
+
+- **`methods`** is the registry of method ids. It may be a mapping of `id: "Display Name"` (used in the character sheet's Focus panel) or a plain list of ids. If omitted, the registry is inferred from the union of the per-Tradition lists.
+- **`traditions`** maps each Tradition to the methods it permits. Keys match the `id` *or* `name` from `chargen.yaml` — `virtual_adepts` and `"Virtual Adepts"` both work.
+- **`default`** (optional) supplies methods for any Tradition not explicitly listed (and for characters with no Tradition). Without it, unlisted Traditions can use no methods.
+
+The whole block is optional. Omit it and `can_use()` returns `True` for everything. The pre-processor's identifier validation also checks `[via method]` names against this registry and suggests corrections for typos.
+
 ### resources.yaml
 
 See [Section 6: Resources](#6-resources) for the full format. Key sections:
@@ -929,6 +999,7 @@ Test files:
 |------|----------|
 | `tests/test_engine.py` | Character creation, trait get/set/advance, range validation, constraints, temporary modifiers |
 | `tests/test_gating.py` | Gate operators, merit checks, module-level gating |
+| `tests/test_paradigm.py` | Paradigm/Focus gating — per-Tradition casting methods, `via` shorthand |
 | `tests/test_resources.py` | Spend/gain, linked pools (Quintessence Wheel), pool caps |
 | `tests/test_chargen.py` | ChargenState, PointPool allocation, build_character |
 | `tests/test_syntax.py` | Bracket shorthand parsing and transformation |

--- a/game/script.rpy
+++ b/game/script.rpy
@@ -25,9 +25,19 @@ label start:
 
     "Your Avatar stirs. There are several ways to approach this."
 
+    ## Paradigm/Focus gating — Elena is a Virtual Adept, so her paradigm-appropriate
+    ## methods are code and hypertech, never prayer. can_use() reflects that.
+    if pc.can_use("prayer"):
+        elena "I could pray for a way through."
+    else:
+        elena "Prayer isn't my Focus. I'm a Virtual Adept — reality is just code waiting to be rewritten."
+
     menu ward_choice:
         "Analyze the ward's Pattern" if pc.gate("Forces", ">=", 3) and pc.gate("Prime", ">=", 2):
             jump analyze_ward
+
+        "Rewrite the ward's source" if pc.can_use("code"):
+            jump rewrite_code
 
         "Brute-force the encryption" if pc.gate("Technology", ">=", 3):
             jump brute_force
@@ -37,6 +47,22 @@ label start:
 
         "This is beyond me. Leave.":
             jump leave
+
+
+label rewrite_code:
+
+    elena "Everything's information. This ward is no exception."
+
+    "You open a console only you can see and begin rewriting the ward's defining parameters from the inside."
+
+    if pc.gate("Correspondence", ">=", 1):
+        "Your grasp of Correspondence lets you reach the ward as if you were already standing within it."
+        elena "There. As far as the Pattern is concerned, I was always supposed to be here."
+    else:
+        "Without Correspondence you can only nudge the edges — but it is enough to slip a process through the gap."
+        elena "Crude. But it worked."
+
+    jump epilogue
 
 
 label analyze_ward:
@@ -138,6 +164,7 @@ label epilogue:
     "This demo exercised the WoD VN Framework's core features:"
     "  - Character loading from YAML"
     "  - Stat-gated menu choices (Forces, Prime, Technology, Awareness)"
+    "  - Paradigm/Focus gating (a Virtual Adept casts via code, not prayer)"
     "  - Resource spending (Quintessence)"
     "  - Linked pool constraints (Paradox gain)"
     "  - Outcome branching based on stat levels"

--- a/game/splats/mage/schema.yaml
+++ b/game/splats/mage/schema.yaml
@@ -107,3 +107,33 @@ trait_constraints:
     target_category: spheres
     limited_by: Arete
     rule: "No Sphere can exceed Arete rating"
+
+# Optional paradigm/focus system. Each Tradition channels magick through its own
+# paradigm-appropriate methods: a Virtual Adept casts through code, never prayer;
+# a Celestial Chorister is the reverse. Authors gate choices with the `via`
+# shorthand — "Pray over the ward" [via prayer] — or pc.can_use("prayer").
+# Tradition keys match the ids/names in chargen.yaml (either form works).
+paradigm:
+  methods:
+    prayer: "Prayer & Faith"
+    ritual: "High Ritual Magick"
+    code: "Cybernetics & Code"
+    science: "Hypertech & Mad Science"
+    blood: "Blood & Sympathetic Magic"
+    herbalism: "Herbalism & Wortcunning"
+    meditation: "Meditation & Inner Focus"
+    martial_arts: "Martial Arts (Do)"
+    art: "Art & Performance"
+    dreaming: "Dreaming & Trance"
+    spirit_speech: "Spirit-Speech & Shamanism"
+    death_work: "Death-Work & Fate"
+  traditions:
+    akashic_brotherhood: [meditation, martial_arts]
+    celestial_chorus: [prayer, art]
+    cult_of_ecstasy: [art, dreaming]
+    dreamspeakers: [spirit_speech, dreaming]
+    euthanatos: [death_work, meditation]
+    order_of_hermes: [ritual]
+    sons_of_ether: [science]
+    verbena: [blood, herbalism, ritual]
+    virtual_adepts: [code, science]

--- a/game/wod_core/__init__.py
+++ b/game/wod_core/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 __version__ = "0.1.0"
 
-from wod_core.gating import gate, has, set_active, get_active
+from wod_core.gating import gate, has, can_use, set_active, get_active
 from wod_core.loader import SplatLoader
 
 _loader: SplatLoader | None = None

--- a/game/wod_core/engine.py
+++ b/game/wod_core/engine.py
@@ -23,13 +23,105 @@ class CategoryDef:
             self.trait_names = list(data["traits"])
 
 
+def _normalize_tradition(key: str) -> str:
+    """Normalize a Tradition id/name so authors can key by either.
+
+    "Virtual Adepts" and "virtual_adepts" both normalize to "virtual_adepts".
+    """
+    return key.strip().lower().replace(" ", "_").replace("-", "_")
+
+
+class Paradigm:
+    """Optional paradigm/focus system — which casting *methods* each Tradition allows.
+
+    A Virtual Adept can cast through "code" but not "prayer"; a Celestial Chorister
+    is the reverse. Authors declare a registry of methods plus a per-Tradition
+    allow-list, then gate choices with ``can_use("method")``.
+
+    Parsed from a schema's optional ``paradigm`` block::
+
+        paradigm:
+          methods:                  # registry (id -> display name); optional
+            code: "Cybernetics & Code"
+            prayer: "Prayer & Faith"
+          traditions:               # per-Tradition allow-lists
+            virtual_adepts: [code, science]
+            celestial_chorus: [prayer, art]
+            default: [code]         # optional fallback for unlisted Traditions
+
+    ``methods`` may also be a plain list of ids; display names then default to
+    the id. If ``methods`` is omitted entirely, the registry is inferred from
+    the union of the per-Tradition lists.
+    """
+
+    def __init__(self, data: dict):
+        self.method_names: dict[str, str] = {}
+        methods = data.get("methods")
+        if isinstance(methods, dict):
+            for mid, disp in methods.items():
+                self.method_names[mid] = disp if isinstance(disp, str) else mid
+        elif isinstance(methods, list):
+            for item in methods:
+                if isinstance(item, dict):
+                    mid = item.get("id")
+                    if mid is None and len(item) == 1:
+                        mid, disp = next(iter(item.items()))
+                        self.method_names[mid] = disp
+                    elif mid is not None:
+                        self.method_names[mid] = item.get("name", mid)
+                else:
+                    self.method_names[item] = item
+
+        self.tradition_methods: dict[str, set[str]] = {}
+        for trad, mlist in (data.get("traditions") or {}).items():
+            self.tradition_methods[_normalize_tradition(trad)] = set(mlist or [])
+
+    @property
+    def declared_methods(self) -> list[str]:
+        """Method ids in the explicit registry (insertion order)."""
+        return list(self.method_names.keys())
+
+    def all_methods(self) -> set[str]:
+        """Every method id known to the paradigm (registry + all Tradition lists)."""
+        methods = set(self.method_names)
+        for allowed in self.tradition_methods.values():
+            methods |= allowed
+        return methods
+
+    def methods_for(self, tradition: str | None) -> set[str]:
+        """Methods permitted to a Tradition, falling back to ``default`` if listed."""
+        if tradition:
+            norm = _normalize_tradition(tradition)
+            if norm in self.tradition_methods:
+                return self.tradition_methods[norm]
+        return self.tradition_methods.get("default", set())
+
+    def can_use(self, method: str, tradition: str | None) -> bool:
+        return method in self.methods_for(tradition)
+
+    def display_name(self, method: str) -> str:
+        return self.method_names.get(method, method)
+
+    def to_dict(self) -> dict:
+        """Reconstruct the raw ``paradigm`` block (for pickle / override round-trips)."""
+        data: dict = {}
+        if self.method_names:
+            data["methods"] = dict(self.method_names)
+        if self.tradition_methods:
+            data["traditions"] = {
+                trad: sorted(methods) for trad, methods in self.tradition_methods.items()
+            }
+        return data
+
+
 class Schema:
-    """Splat schema — trait categories, ranges, defaults, constraints."""
+    """Splat schema — trait categories, ranges, defaults, constraints, paradigm."""
 
     def __init__(self, data: dict):
         self.categories: dict[str, CategoryDef] = {}
         self.trait_lookup: dict[str, str] = {}
         self.constraints: list[Constraint] = []
+        self.paradigm: Paradigm | None = None
         self._parse(data)
 
     def _parse(self, data: dict) -> None:
@@ -47,6 +139,9 @@ class Schema:
         for constraint_data in data.get("trait_constraints", []):
             self.constraints.append(Constraint.from_dict(constraint_data))
 
+        if data.get("paradigm"):
+            self.paradigm = Paradigm(data["paradigm"])
+
     def get_all_trait_names(self) -> list[str]:
         return list(self.trait_lookup.keys())
 
@@ -60,6 +155,42 @@ class Schema:
     def get_default(self, trait_name: str) -> int:
         cat_name = self.trait_lookup[trait_name]
         return self.categories[cat_name].default
+
+    def can_use(self, method: str, tradition: str | None) -> bool:
+        """Whether a Tradition may cast via ``method``.
+
+        Returns ``True`` when no paradigm is configured — the optional system
+        is simply off, so nothing is restricted.
+        """
+        if self.paradigm is None:
+            return True
+        return self.paradigm.can_use(method, tradition)
+
+    def to_dict(self) -> dict:
+        """Serialize back to a raw schema dict (categories, constraints, paradigm)."""
+        data: dict = {"trait_categories": {}, "trait_constraints": []}
+        for cat_name, cat in self.categories.items():
+            cat_data: dict = {
+                "display_name": cat.display_name,
+                "range": list(cat.range),
+                "default": cat.default,
+            }
+            if cat.groups is not None:
+                cat_data["groups"] = {k: list(v) for k, v in cat.groups.items()}
+            else:
+                cat_data["traits"] = list(cat.trait_names)
+            data["trait_categories"][cat_name] = cat_data
+        for constraint in self.constraints:
+            if isinstance(constraint, MaxLinkedConstraint):
+                data["trait_constraints"].append({
+                    "type": "max_linked",
+                    "target_category": constraint.target_category,
+                    "limited_by": constraint.limited_by,
+                    "rule": constraint.rule,
+                })
+        if self.paradigm is not None:
+            data["paradigm"] = self.paradigm.to_dict()
+        return data
 
 
 class Constraint:
@@ -207,6 +338,14 @@ class Character:
     def has(self, name: str) -> bool:
         return any(mf["name"] == name for mf in self.merits_flaws)
 
+    def can_use(self, method: str) -> bool:
+        """Whether this character's paradigm permits casting via ``method``.
+
+        Resolves the character's Tradition from ``identity["tradition"]``. Returns
+        ``True`` when the schema defines no paradigm (the optional system is off).
+        """
+        return self.schema.can_use(method, self.identity.get("tradition"))
+
     _OPERATORS = {
         ">=": lambda a, b: a >= b,
         "<=": lambda a, b: a <= b,
@@ -228,35 +367,14 @@ class Character:
         return self._OPERATORS[op](current, value)
 
     def __getstate__(self):
-        """Exclude Schema object from pickle — store raw data instead."""
+        """Exclude Schema object from pickle — store reconstructable raw data instead."""
         state = self.__dict__.copy()
         # Temporary modifiers are reapplied by game logic — never persisted.
         state.pop("modifiers", None)
         # Schema is large and reconstructable — store the raw data instead
         if "schema" in state:
             schema = state.pop("schema")
-            # Reconstruct the data dict from the Schema object
-            schema_data: dict = {"trait_categories": {}, "trait_constraints": []}
-            for cat_name, cat in schema.categories.items():
-                cat_data: dict = {
-                    "display_name": cat.display_name,
-                    "range": list(cat.range),
-                    "default": cat.default,
-                }
-                if cat.groups is not None:
-                    cat_data["groups"] = {k: list(v) for k, v in cat.groups.items()}
-                else:
-                    cat_data["traits"] = list(cat.trait_names)
-                schema_data["trait_categories"][cat_name] = cat_data
-            for constraint in schema.constraints:
-                if isinstance(constraint, MaxLinkedConstraint):
-                    schema_data["trait_constraints"].append({
-                        "type": "max_linked",
-                        "target_category": constraint.target_category,
-                        "limited_by": constraint.limited_by,
-                        "rule": constraint.rule,
-                    })
-            state["_schema_data"] = schema_data
+            state["_schema_data"] = schema.to_dict() if schema is not None else None
         return state
 
     def __setstate__(self, state):

--- a/game/wod_core/gating.py
+++ b/game/wod_core/gating.py
@@ -26,3 +26,7 @@ def gate(name: str, op: str, value: int) -> bool:
 
 def has(name: str) -> bool:
     return get_active().has(name)
+
+
+def can_use(method: str) -> bool:
+    return get_active().can_use(method)

--- a/game/wod_core/loader.py
+++ b/game/wod_core/loader.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 
 import yaml
 
-from wod_core.engine import Schema, Character, MaxLinkedConstraint
+from wod_core.engine import Schema, Character
 from wod_core.resources import ResourceManager
 
 
@@ -221,24 +221,4 @@ class SplatLoader:
     @staticmethod
     def _schema_to_dict(schema: Schema) -> dict:
         """Convert a Schema back to a raw dict for override merging."""
-        data: dict = {"trait_categories": {}, "trait_constraints": []}
-        for cat_name, cat in schema.categories.items():
-            cat_data: dict = {
-                "display_name": cat.display_name,
-                "range": list(cat.range),
-                "default": cat.default,
-            }
-            if cat.groups is not None:
-                cat_data["groups"] = {k: list(v) for k, v in cat.groups.items()}
-            else:
-                cat_data["traits"] = list(cat.trait_names)
-            data["trait_categories"][cat_name] = cat_data
-        for constraint in schema.constraints:
-            if isinstance(constraint, MaxLinkedConstraint):
-                data["trait_constraints"].append({
-                    "type": "max_linked",
-                    "target_category": constraint.target_category,
-                    "limited_by": constraint.limited_by,
-                    "rule": constraint.rule,
-                })
-        return data
+        return schema.to_dict()

--- a/game/wod_core/syntax.py
+++ b/game/wod_core/syntax.py
@@ -2,8 +2,10 @@
 
 Transforms lines like:
     "Choice text" [Forces >= 3, Prime >= 2]:
+    "Pray over it" [via prayer]:
 Into:
     "Choice text" if wod_core.gate("Forces", ">=", 3) and wod_core.gate("Prime", ">=", 2):
+    "Pray over it" if wod_core.can_use("prayer"):
 """
 
 from __future__ import annotations
@@ -23,16 +25,25 @@ _COMPARISON_RE = re.compile(
 
 _NEGATION_RE = re.compile(r'^!(.+)$')
 
+# Paradigm/focus method gate: "via prayer" -> can_use("prayer").
+_VIA_RE = re.compile(r'^via\s+(.+)$', re.IGNORECASE)
+
 # Phase 2: identifier validation registry
 _encountered_identifiers: set[str] = set()
+_encountered_methods: set[str] = set()
 
 
 def _register_identifier(name: str) -> None:
     _encountered_identifiers.add(name)
 
 
+def _register_method(name: str) -> None:
+    _encountered_methods.add(name)
+
+
 def clear_identifiers() -> None:
     _encountered_identifiers.clear()
+    _encountered_methods.clear()
 
 
 def parse_condition(cond: str) -> str:
@@ -47,10 +58,18 @@ def parse_condition(cond: str) -> str:
         _register_identifier(trait_name)
         return f'wod_core.gate("{trait_name}", "{op}", {value})'
 
-    m = _NEGATION_RE.match(cond)
-    if m:
-        name = m.group(1).strip()
-        return f'not wod_core.has("{name}")'
+    # Paradigm/focus method gate, optionally negated: "via X" / "!via X".
+    neg = _NEGATION_RE.match(cond)
+    body = neg.group(1).strip() if neg else cond
+    via = _VIA_RE.match(body)
+    if via:
+        method = via.group(1).strip()
+        _register_method(method)
+        expr = f'wod_core.can_use("{method}")'
+        return f"not {expr}" if neg else expr
+
+    if neg:
+        return f'not wod_core.has("{body}")'
 
     return f'wod_core.has("{cond}")'
 
@@ -85,7 +104,12 @@ def _closest_match(name: str, valid_names: list[str]) -> str | None:
 def validate_identifiers(
     schema, resource_names: list[str] | None = None
 ) -> list[str]:
-    """Validate all encountered identifiers against the schema and resources."""
+    """Validate all encountered identifiers against the schema and resources.
+
+    Trait/resource names (from comparison gates) are checked against the schema
+    and resource pools. Casting methods (from ``via`` gates) are checked against
+    the schema's paradigm registry, when one is defined.
+    """
     valid_names = set(schema.get_all_trait_names())
     if resource_names:
         valid_names.update(resource_names)
@@ -98,4 +122,17 @@ def validate_identifiers(
             if suggestion:
                 msg += f' Did you mean "{suggestion}"?'
             errors.append(msg)
+
+    paradigm = getattr(schema, "paradigm", None)
+    if paradigm is not None:
+        valid_methods = paradigm.all_methods()
+        if valid_methods:
+            for method in _encountered_methods:
+                if method not in valid_methods:
+                    msg = f'Unknown casting method "{method}" in via condition.'
+                    suggestion = _closest_match(method, list(valid_methods))
+                    if suggestion:
+                        msg += f' Did you mean "{suggestion}"?'
+                    errors.append(msg)
+
     return errors

--- a/game/wod_screens/character_sheet.rpy
+++ b/game/wod_screens/character_sheet.rpy
@@ -156,6 +156,18 @@ screen character_sheet():
                                             $ pool_text = "{}/{}".format(pool.current(), pool.max)
                                             text "[pool_text]" size 12 color "#888888"
 
+                                # Focus — paradigm-appropriate casting methods for this Tradition
+                                $ paradigm = getattr(schema, "paradigm", None)
+                                if paradigm is not None:
+                                    $ focus_methods = sorted(paradigm.methods_for(pc.identity.get("tradition", "")))
+                                    if focus_methods:
+                                        null height 15
+                                        text "Focus" size 20 color "#b8860b"
+                                        null height 5
+                                        for method_id in focus_methods:
+                                            $ method_label = paradigm.display_name(method_id)
+                                            text "[method_label]" size 14 color "#e0e0e0"
+
     key "K_ESCAPE" action Hide("character_sheet")
     key "K_TAB" action Hide("character_sheet")
 

--- a/tests/test_paradigm.py
+++ b/tests/test_paradigm.py
@@ -1,0 +1,312 @@
+# tests/test_paradigm.py
+"""Paradigm/Focus gating — Tradition-appropriate casting methods (issue #22)."""
+
+import copy
+import os
+import pickle
+
+import pytest
+
+import wod_core
+from wod_core.engine import Schema, Character, Paradigm, _normalize_tradition
+from wod_core.resources import ResourceManager
+from wod_core import syntax
+
+
+GAME_DIR = os.path.join(os.path.dirname(__file__), "..", "game")
+
+# A compact paradigm used across the unit tests.
+PARADIGM_DATA = {
+    "methods": {
+        "code": "Cybernetics & Code",
+        "science": "Hypertech & Mad Science",
+        "prayer": "Prayer & Faith",
+        "ritual": "High Ritual Magick",
+        "blood": "Blood Magic",
+    },
+    "traditions": {
+        "virtual_adepts": ["code", "science"],
+        "celestial_chorus": ["prayer"],
+        "order_of_hermes": ["ritual"],
+        "verbena": ["blood", "ritual"],
+    },
+}
+
+
+@pytest.fixture
+def paradigm_schema_data(mage_schema_data):
+    """The minimal Mage schema with a paradigm block attached."""
+    data = copy.deepcopy(mage_schema_data)
+    data["paradigm"] = copy.deepcopy(PARADIGM_DATA)
+    return data
+
+
+class TestNormalizeTradition:
+    """Tradition keys may be written as ids or display names."""
+
+    def test_name_normalizes_to_id(self):
+        assert _normalize_tradition("Virtual Adepts") == "virtual_adepts"
+        assert _normalize_tradition("Order of Hermes") == "order_of_hermes"
+        assert _normalize_tradition("Sons of Ether") == "sons_of_ether"
+
+    def test_id_unchanged(self):
+        assert _normalize_tradition("virtual_adepts") == "virtual_adepts"
+
+    def test_handles_hyphens_and_whitespace(self):
+        assert _normalize_tradition("  Cult-of-Ecstasy  ") == "cult_of_ecstasy"
+
+
+class TestParadigmParsing:
+    """Parse the various accepted shapes of the paradigm block."""
+
+    def test_methods_dict_keeps_display_names(self):
+        p = Paradigm(PARADIGM_DATA)
+        assert p.display_name("code") == "Cybernetics & Code"
+        assert p.display_name("prayer") == "Prayer & Faith"
+
+    def test_methods_list_of_ids(self):
+        p = Paradigm({"methods": ["code", "prayer"], "traditions": {}})
+        assert set(p.declared_methods) == {"code", "prayer"}
+        # No display name supplied -> falls back to the id.
+        assert p.display_name("code") == "code"
+
+    def test_methods_list_of_single_key_dicts(self):
+        p = Paradigm({"methods": [{"code": "Code"}, {"prayer": "Prayer"}]})
+        assert p.display_name("code") == "Code"
+        assert p.display_name("prayer") == "Prayer"
+
+    def test_methods_list_of_id_name_dicts(self):
+        p = Paradigm({"methods": [{"id": "code", "name": "Code"}]})
+        assert p.display_name("code") == "Code"
+
+    def test_tradition_keys_normalized(self):
+        p = Paradigm({"traditions": {"Virtual Adepts": ["code"]}})
+        assert p.methods_for("virtual_adepts") == {"code"}
+        assert p.methods_for("Virtual Adepts") == {"code"}
+
+    def test_all_methods_unions_registry_and_traditions(self):
+        p = Paradigm({"methods": ["code"], "traditions": {"verbena": ["blood", "ritual"]}})
+        assert p.all_methods() == {"code", "blood", "ritual"}
+
+    def test_registry_inferred_when_methods_omitted(self):
+        p = Paradigm({"traditions": {"verbena": ["blood", "ritual"]}})
+        assert p.declared_methods == []
+        assert p.all_methods() == {"blood", "ritual"}
+
+
+class TestMethodsFor:
+    """Resolving which methods a Tradition may use."""
+
+    def test_lookup_by_id(self):
+        p = Paradigm(PARADIGM_DATA)
+        assert p.methods_for("virtual_adepts") == {"code", "science"}
+
+    def test_lookup_by_display_name(self):
+        p = Paradigm(PARADIGM_DATA)
+        assert p.methods_for("Virtual Adepts") == {"code", "science"}
+
+    def test_unknown_tradition_without_default_is_empty(self):
+        p = Paradigm(PARADIGM_DATA)
+        assert p.methods_for("Hollow Ones") == set()
+
+    def test_none_tradition_is_empty(self):
+        p = Paradigm(PARADIGM_DATA)
+        assert p.methods_for(None) == set()
+
+    def test_default_fallback(self):
+        data = copy.deepcopy(PARADIGM_DATA)
+        data["traditions"]["default"] = ["ritual"]
+        p = Paradigm(data)
+        assert p.methods_for("Hollow Ones") == {"ritual"}
+        assert p.methods_for(None) == {"ritual"}
+        # Explicit Traditions still take precedence over default.
+        assert p.methods_for("virtual_adepts") == {"code", "science"}
+
+
+class TestParadigmCanUse:
+    def test_can_use_true_and_false(self):
+        p = Paradigm(PARADIGM_DATA)
+        assert p.can_use("code", "virtual_adepts") is True
+        assert p.can_use("prayer", "virtual_adepts") is False
+        assert p.can_use("prayer", "Celestial Chorus") is True
+
+
+class TestSchemaCanUse:
+    def test_schema_with_paradigm(self, paradigm_schema_data):
+        schema = Schema(paradigm_schema_data)
+        assert schema.paradigm is not None
+        assert schema.can_use("code", "Virtual Adepts") is True
+        assert schema.can_use("prayer", "Virtual Adepts") is False
+
+    def test_schema_without_paradigm_is_permissive(self, mage_schema_data):
+        """The system is optional: with no paradigm, nothing is restricted."""
+        schema = Schema(mage_schema_data)
+        assert schema.paradigm is None
+        assert schema.can_use("anything", "Virtual Adepts") is True
+        assert schema.can_use("prayer", None) is True
+
+
+class TestCharacterCanUse:
+    def test_uses_identity_tradition(self, paradigm_schema_data):
+        schema = Schema(paradigm_schema_data)
+        char = Character(schema, identity={"tradition": "Virtual Adepts"})
+        assert char.can_use("code") is True
+        assert char.can_use("science") is True
+        assert char.can_use("prayer") is False
+
+    def test_chorister_can_pray(self, paradigm_schema_data):
+        schema = Schema(paradigm_schema_data)
+        char = Character(schema, identity={"tradition": "Celestial Chorus"})
+        assert char.can_use("prayer") is True
+        assert char.can_use("code") is False
+
+    def test_character_without_tradition(self, paradigm_schema_data):
+        schema = Schema(paradigm_schema_data)
+        char = Character(schema)
+        assert char.can_use("code") is False
+
+    def test_permissive_without_paradigm(self, mage_schema_data):
+        schema = Schema(mage_schema_data)
+        char = Character(schema, identity={"tradition": "Virtual Adepts"})
+        assert char.can_use("prayer") is True
+
+
+class TestModuleLevelCanUse:
+    def test_set_active_and_can_use(self, paradigm_schema_data):
+        schema = Schema(paradigm_schema_data)
+        char = Character(schema, identity={"tradition": "Virtual Adepts"})
+        wod_core.set_active(char)
+        assert wod_core.can_use("code") is True
+        assert wod_core.can_use("prayer") is False
+
+    def test_can_use_without_active_raises(self):
+        wod_core.set_active(None)
+        with pytest.raises(RuntimeError, match="No active character"):
+            wod_core.can_use("code")
+
+
+class TestViaSyntax:
+    """Bracket shorthand: [via method] -> wod_core.can_use("method")."""
+
+    def setup_method(self):
+        syntax.clear_identifiers()
+
+    def test_parse_via(self):
+        assert syntax.parse_condition("via prayer") == 'wod_core.can_use("prayer")'
+
+    def test_parse_via_negated(self):
+        assert syntax.parse_condition("!via prayer") == 'not wod_core.can_use("prayer")'
+
+    def test_parse_via_case_insensitive(self):
+        assert syntax.parse_condition("VIA code") == 'wod_core.can_use("code")'
+
+    def test_parse_multi_word_method(self):
+        assert syntax.parse_condition("via spirit speech") == 'wod_core.can_use("spirit speech")'
+
+    def test_via_does_not_misfire_on_word_starting_with_via(self):
+        # "Vianna" has no space after "via" -> treated as a merit check, not a method.
+        assert syntax.parse_condition("Vianna") == 'wod_core.has("Vianna")'
+
+    def test_transform_line_via(self):
+        line = '    "Pray over the ward" [via prayer]:'
+        expected = '    "Pray over the ward" if wod_core.can_use("prayer"):'
+        assert syntax.transform_line(line) == expected
+
+    def test_transform_line_mixed_gate_and_via(self):
+        line = '    "Rewrite the ward" [Forces >= 3, via code]:'
+        expected = '    "Rewrite the ward" if wod_core.gate("Forces", ">=", 3) and wod_core.can_use("code"):'
+        assert syntax.transform_line(line) == expected
+
+    def test_clear_identifiers_clears_methods(self):
+        syntax.parse_condition("via prayer")
+        syntax.clear_identifiers()
+        assert syntax._encountered_methods == set()
+
+
+class TestValidateMethods:
+    def setup_method(self):
+        syntax.clear_identifiers()
+
+    def test_valid_method_passes(self, paradigm_schema_data):
+        schema = Schema(paradigm_schema_data)
+        syntax.parse_condition("via code")
+        assert syntax.validate_identifiers(schema) == []
+
+    def test_unknown_method_errors_with_suggestion(self, paradigm_schema_data):
+        schema = Schema(paradigm_schema_data)
+        syntax.parse_condition("via cod")  # typo
+        errors = syntax.validate_identifiers(schema)
+        assert len(errors) == 1
+        assert "cod" in errors[0]
+        assert "code" in errors[0]  # did-you-mean
+
+    def test_methods_not_validated_without_paradigm(self, mage_schema_data):
+        schema = Schema(mage_schema_data)
+        syntax.parse_condition("via whatever")
+        # No paradigm registry -> method validation is skipped entirely.
+        assert syntax.validate_identifiers(schema) == []
+
+
+class TestParadigmSerialization:
+    """Paradigm must survive Schema.to_dict() and the pickle round-trip (saves)."""
+
+    def test_paradigm_to_dict_round_trip(self):
+        p = Paradigm(PARADIGM_DATA)
+        reparsed = Paradigm(p.to_dict())
+        assert reparsed.methods_for("virtual_adepts") == {"code", "science"}
+        assert reparsed.display_name("code") == "Cybernetics & Code"
+        assert reparsed.all_methods() == p.all_methods()
+
+    def test_schema_to_dict_includes_paradigm(self, paradigm_schema_data):
+        schema = Schema(paradigm_schema_data)
+        rebuilt = Schema(schema.to_dict())
+        assert rebuilt.can_use("code", "Virtual Adepts") is True
+        assert rebuilt.can_use("prayer", "Virtual Adepts") is False
+
+    def test_schema_to_dict_omits_paradigm_when_absent(self, mage_schema_data):
+        schema = Schema(mage_schema_data)
+        assert "paradigm" not in schema.to_dict()
+
+    def test_pickle_preserves_can_use(self, paradigm_schema_data):
+        schema = Schema(paradigm_schema_data)
+        char = Character(schema, traits={"Arete": 3, "Forces": 2},
+                         identity={"tradition": "Virtual Adepts"})
+        char.resources = ResourceManager({"resources": {}, "resource_links": {}})
+
+        restored = pickle.loads(pickle.dumps(char))
+
+        assert restored.can_use("code") is True
+        assert restored.can_use("prayer") is False
+
+
+class TestRealMageParadigm:
+    """The shipped Mage schema defines a paradigm for all nine Traditions."""
+
+    def setup_method(self):
+        wod_core.init(GAME_DIR)
+        wod_core.load_splat("mage")
+
+    def test_schema_has_paradigm(self):
+        schema = wod_core.get_loader().loaded_splats["mage"].schema
+        assert schema.paradigm is not None
+        # Every Tradition in chargen.yaml has a paradigm entry.
+        chargen = wod_core.get_loader().loaded_splats["mage"].chargen_config
+        for trad in chargen["traditions"]:
+            assert schema.paradigm.methods_for(trad["id"]), trad["id"]
+
+    def test_demo_virtual_adept(self):
+        char = wod_core.load_character("demo/elena.yaml")
+        assert char.can_use("code") is True
+        assert char.can_use("science") is True
+        # The headline example from the issue: a Virtual Adept can't pray.
+        assert char.can_use("prayer") is False
+
+    def test_verbena_and_hermetic_methods(self):
+        schema = wod_core.get_loader().loaded_splats["mage"].schema
+        verbena = Character(schema, identity={"tradition": "Verbena"})
+        assert verbena.can_use("blood") is True
+        assert verbena.can_use("code") is False
+
+        hermetic = Character(schema, identity={"tradition": "Order of Hermes"})
+        assert hermetic.can_use("ritual") is True
+        assert hermetic.can_use("blood") is False


### PR DESCRIPTION
Closes #22.

## What & why

A Virtual Adept can't cast through prayer; a Verbena can't cast through code. This adds an **optional** system where a splat's schema declares the paradigm-appropriate **casting methods** per Tradition, so authors can gate choices on paradigm as well as stats.

The system is opt-in and backward-compatible: if a splat defines no `paradigm`, `can_use()` returns `True` for everything and nothing changes for existing games.

## Engine

- **`Paradigm`** (new) parses an optional `paradigm` block in `schema.yaml`: a method registry (`id: "Display Name"`, or a plain list of ids) plus per-Tradition allow-lists. Tradition keys are normalized so `virtual_adepts` and `"Virtual Adepts"` both match, and an optional `default` list covers unlisted Traditions.
- **`Character.can_use(method)`** / **`Schema.can_use(method, tradition)`** / module-level **`wod_core.can_use(method)`** — mirrors the existing `gate()`/`has()` API. Resolves the Tradition from `identity["tradition"]`.
- Schema serialization is centralized in **`Schema.to_dict()`**, now used by both the pickle path (`Character.__getstate__`) and the template-override path (`loader._schema_to_dict`), so the paradigm **survives save/load**. (Previously each path hand-rolled the dict; the duplication is gone.)

## Authoring

- **Bracket shorthand:** `"Pray over it" [via prayer]:` → `wod_core.can_use("prayer")`, and `[!via prayer]` negates it. The pre-processor validates method names against the paradigm registry and offers "did you mean" suggestions for typos.
- The **Mage schema** ships a paradigm for all nine Traditions (e.g. Virtual Adepts → `code`, `science`; Celestial Chorus → `prayer`, `art`).
- The **demo** (`script.rpy`) shows both the positive (`can_use("code")`) and negative (`can_use("prayer")`) cases, and the **character sheet** gains a read-only **Focus** panel listing the character's permitted methods.

## Docs & tests

- Author guide: new *Paradigm & Focus Gating* section, a `schema.yaml` paradigm reference, and the `[via method]` shorthand rule. README feature/test list updated.
- **42 new tests** in `tests/test_paradigm.py` covering parsing shapes, Tradition normalization, `can_use` resolution (incl. `default` and the disabled/permissive case), the `via` shorthand, method validation, the `Schema.to_dict()`/pickle round-trip, and the shipped Mage paradigm.

## Verification

- Full suite green: **164 passed** (122 existing + 42 new).
- End-to-end check against the real splat: Elena (Virtual Adept) `can_use("code") == True`, `can_use("prayer") == False`, and that result survives a pickle round-trip.

> Note: the Ren'Py screen/script changes can't be linted in this environment (no Ren'Py SDK). They use only constructs already present in those files; a `renpy.sh . lint` before merge is recommended.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HpnaXwK28o1A84Bx6rSLCB)_