### PR TITLE
feat: version-aware save migration for schema changes (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ You write your story in Ren'Py. The framework handles character stats, resource 
 - **Toast notifications** -- brief on-screen messages for gate results, stat changes, or custom alerts.
 - **Bracket shorthand pre-processor** -- write `[Forces >= 3]` in your script; a CLI tool compiles it to native Ren'Py `if` expressions.
 - **Save/load serialization optimization** -- Character objects pickle efficiently by excluding the Schema and reconstructing it on load.
+- **Versioned save migration** -- bump your schema's `version` and old saves are reconciled to the new schema on load: new traits default in, removed traits drop, out-of-range values clamp, and renames are handled by author-registered migration steps.
 - **Author-level splat overrides and template extension** -- add traits, tweak resources, or create archetype variants without modifying the base splat files.
 
 ## Quick Start

--- a/docs/author-guide.md
+++ b/docs/author-guide.md
@@ -1012,6 +1012,16 @@ do not bump the version, no migration runs** -- this is deliberate, so that
 author-level overrides and template-extended characters (which share the base
 version) keep their custom schemas.
 
+> **Template-extended characters and version bumps.** A character loaded via
+> `load_character_from_template` with overrides (e.g. an archmage with a wider
+> Sphere range) carries its own extended schema. As long as you do not bump the
+> base version, it keeps that schema untouched. When you *do* bump the version,
+> it is reconciled onto the canonical schema like any other save -- override-only
+> traits are dropped and wider ranges are clamped to the canonical range (the
+> changes are reported via the load toast and log). If you need such a character
+> to retain its extensions across a version bump, reapply the overrides after
+> load, or fold them into the base schema.
+
 #### Automatic reconciliation
 
 Most changes need no extra code. When the version changes, the framework
@@ -1023,6 +1033,7 @@ reconciles every saved character against the new schema:
 | **Trait removed** | Dropped from the character. |
 | **Range narrowed** | Out-of-range values are clamped into the new range. |
 | **Range widened** | Values are unchanged. |
+| **Constraint left violated** | If clamping a trait leaves an inter-trait constraint broken (e.g. a Sphere now exceeds a lowered Arete), the dependent trait is lowered until the constraint holds. |
 
 This is graceful by default: the save loads, changes are logged, and a brief
 toast tells the player their save was updated.

--- a/docs/author-guide.md
+++ b/docs/author-guide.md
@@ -987,6 +987,91 @@ overrides:
       range: [0, 12]
 ```
 
+### Schema Versioning & Save Migration
+
+If you release an update that changes your schema -- renaming a trait, adding or
+removing one, or narrowing a range -- characters in players' existing save files
+were written against the *old* schema. The framework migrates them onto the new
+schema automatically when a save is loaded, so old saves keep working.
+
+#### Bump the version when you change the schema
+
+Migration is triggered by the `version` field in `schema.yaml` (it falls back to
+the `version` in `manifest.yaml` if the schema file omits one):
+
+```yaml
+# game/splats/mage/schema.yaml
+version: "1.1"   # was "1.0" -- bump this whenever you change traits or ranges
+trait_categories:
+  ...
+```
+
+Each saved character records the schema version it was written under. On load,
+if that version differs from the current one, the character is migrated. **If you
+do not bump the version, no migration runs** -- this is deliberate, so that
+author-level overrides and template-extended characters (which share the base
+version) keep their custom schemas.
+
+#### Automatic reconciliation
+
+Most changes need no extra code. When the version changes, the framework
+reconciles every saved character against the new schema:
+
+| Change | What happens on load |
+|--------|----------------------|
+| **Trait added** | Set to its schema default. |
+| **Trait removed** | Dropped from the character. |
+| **Range narrowed** | Out-of-range values are clamped into the new range. |
+| **Range widened** | Values are unchanged. |
+
+This is graceful by default: the save loads, changes are logged, and a brief
+toast tells the player their save was updated.
+
+#### Migration steps for renames
+
+Reconciliation cannot know that a *renamed* trait should keep its value -- it
+looks like one trait removed and another added. Register a migration step to
+carry the value across. A step receives a mutable `state` dict and runs when a
+save crosses from `from_version` to `to_version`:
+
+```renpy
+init python:
+    @wod_core.migration("mage", "1.0", "1.1")
+    def rename_correspondence(state):
+        # Move the old value to the new key; reconciliation handles the rest.
+        if "Correspondence" in state["traits"]:
+            state["traits"]["Data"] = state["traits"].pop("Correspondence")
+```
+
+The `state` dict exposes `traits` (`{name: value}`), `merits_flaws`, `identity`,
+and `resources` (`{pool: current_value}` for existing pools). Mutate it in place.
+Steps chain by version: a `1.0 -> 1.1` step followed by a `1.1 -> 2.0` step
+migrates a `1.0` save all the way to `2.0`, applying any in-between
+reconciliation for free. (Renaming a resource *pool* is not handled
+automatically; adjust values in `state["resources"]` or rebuild the pool in a
+step if you need that.)
+
+Equivalent non-decorator form:
+
+```renpy
+init python:
+    wod_core.register_migration("mage", "1.0", "1.1", rename_correspondence)
+```
+
+#### Strict mode
+
+By default migration proceeds and warns. To instead fail loudly with a clear
+message whenever a migration would lose or clamp data (useful during
+development, so you notice missing migration steps):
+
+```renpy
+init python:
+    wod_core.migrations.strict = True
+```
+
+In strict mode a problematic load raises `wod_core.MigrationError` describing
+exactly what could not be migrated, rather than silently reconciling.
+
 ---
 
 ## 12. Testing Your Game

--- a/docs/internal/superpowers/specs/2026-03-28-wod-vn-framework-design.md
+++ b/docs/internal/superpowers/specs/2026-03-28-wod-vn-framework-design.md
@@ -631,9 +631,9 @@ Next scene
 
 - All runtime state (trait values, resource pools, merits/flaws, identity) lives in Ren'Py-managed variables.
 - Schema and resource definitions stay in YAML, reloaded on game start.
-- Saving: Ren'Py snapshots the character objects automatically.
-- Loading: Ren'Py restores them, framework re-validates against current schema.
-- Save migration across schema changes (renamed traits, changed ranges) is out of scope for v1. Authors should treat released schema as stable.
+- Saving: Ren'Py snapshots the character objects automatically. Each character records its splat and the schema `version` it was written under.
+- Loading: Ren'Py restores them; if the saved schema version differs from the current one, the framework migrates the character onto the current schema (see below).
+- Save migration across schema changes (renamed traits, added/removed traits, changed ranges) is implemented in `wod_core/migrations.py` (issue #20). Bumping the schema `version` triggers migration on load: new traits default in, removed traits drop, out-of-range values clamp, and authors can register version-to-version steps to preserve renamed-trait values. Migration is graceful by default (warn + reconcile, surfaced via a toast) with an opt-in `strict` mode that raises a clear `MigrationError`.
 
 ### Multi-PC Flow (Opt-in)
 

--- a/game/splats/mage/schema.yaml
+++ b/game/splats/mage/schema.yaml
@@ -1,3 +1,8 @@
+# Schema revision. Bump this whenever you change traits or ranges so that
+# characters saved under the old schema are migrated on load. See the Author
+# Guide section "Save Migration" and wod_core/migrations.py.
+version: "1.0"
+
 trait_categories:
   attributes:
     display_name: "Attributes"

--- a/game/wod_core/__init__.py
+++ b/game/wod_core/__init__.py
@@ -4,8 +4,23 @@ from __future__ import annotations
 
 __version__ = "0.1.0"
 
+from wod_core import migrations
 from wod_core.gating import gate, has, can_use, set_active, get_active
 from wod_core.loader import SplatLoader
+from wod_core.migrations import (
+    MigrationError,
+    migration,
+    register_migration,
+)
+
+
+def drain_migration_reports() -> list:
+    """Return and clear migration reports produced since the last call.
+
+    Surfaced by the framework's ``after_load`` label to notify the player when
+    a save was migrated onto a newer schema version.
+    """
+    return migrations.drain_reports()
 
 _loader: SplatLoader | None = None
 

--- a/game/wod_core/chargen.py
+++ b/game/wod_core/chargen.py
@@ -390,6 +390,7 @@ def _build_from_allocation(state: ChargenState) -> Character:
         traits=flat_traits,
         merits_flaws=merits_flaws,
         identity=identity,
+        splat_id=state.splat_id,
     )
 
     # Attach resources
@@ -436,6 +437,7 @@ def _build_from_template(state: ChargenState) -> Character:
         traits=flat_traits,
         merits_flaws=char_data.get("merits_flaws", []),
         identity=file_identity,
+        splat_id=state.splat_id,
     )
 
     # Attach resources

--- a/game/wod_core/engine.py
+++ b/game/wod_core/engine.py
@@ -115,9 +115,16 @@ class Paradigm:
 
 
 class Schema:
-    """Splat schema — trait categories, ranges, defaults, constraints, paradigm."""
+    """Splat schema — trait categories, ranges, defaults, constraints, paradigm.
+
+    The ``version`` string identifies the schema revision. Authors bump it
+    whenever they change traits or ranges; on load, a saved character whose
+    recorded version differs from the current schema's version is migrated
+    onto the current schema (see ``wod_core.migrations``).
+    """
 
     def __init__(self, data: dict):
+        self.version: str = str(data.get("version", "0"))
         self.categories: dict[str, CategoryDef] = {}
         self.trait_lookup: dict[str, str] = {}
         self.constraints: list[Constraint] = []
@@ -167,8 +174,16 @@ class Schema:
         return self.paradigm.can_use(method, tradition)
 
     def to_dict(self) -> dict:
-        """Serialize back to a raw schema dict (categories, constraints, paradigm)."""
-        data: dict = {"trait_categories": {}, "trait_constraints": []}
+        """Serialize the schema back to a raw data dict (inverse of __init__).
+
+        Used both for character pickling (storing a schema snapshot) and for
+        override merging in the loader, so the two stay in sync.
+        """
+        data: dict = {
+            "version": self.version,
+            "trait_categories": {},
+            "trait_constraints": [],
+        }
         for cat_name, cat in self.categories.items():
             cat_data: dict = {
                 "display_name": cat.display_name,
@@ -245,8 +260,13 @@ class Character:
         traits: dict[str, int] | None = None,
         merits_flaws: list[dict] | None = None,
         identity: dict | None = None,
+        splat_id: str | None = None,
     ):
         self.schema = schema
+        # The splat this character belongs to. Recorded so that, on load, the
+        # framework can locate the splat's current schema and migrate the save
+        # if the schema version has changed since it was written.
+        self.splat_id = splat_id
         self.traits: dict[str, int] = {}
         self.merits_flaws = merits_flaws or []
         self.identity = identity or {}
@@ -367,26 +387,79 @@ class Character:
         return self._OPERATORS[op](current, value)
 
     def __getstate__(self):
-        """Exclude Schema object from pickle — store reconstructable raw data instead."""
+        """Exclude the Schema object from the pickle — store a snapshot instead.
+
+        The schema is large and reconstructable, so we store its raw data dict
+        and version rather than the live object. The version lets ``__setstate__``
+        detect schema changes and migrate the save on load.
+        """
         state = self.__dict__.copy()
         # Temporary modifiers are reapplied by game logic — never persisted.
         state.pop("modifiers", None)
-        # Schema is large and reconstructable — store the raw data instead
-        if "schema" in state:
-            schema = state.pop("schema")
-            state["_schema_data"] = schema.to_dict() if schema is not None else None
+        schema = state.pop("schema", None)
+        if schema is not None:
+            state["_schema_data"] = schema.to_dict()
+            state["_schema_version"] = schema.version
+        else:
+            state["_schema_data"] = None
+            state["_schema_version"] = None
         return state
 
     def __setstate__(self, state):
-        """Reconstruct Schema from stored raw data."""
+        """Restore the character, migrating it onto the current schema if needed.
+
+        Resolution order:
+
+        1. No current schema registered for this splat (e.g. the engine used
+           outside a loaded game, or a pre-versioning save with no ``splat_id``):
+           reconstruct the saved schema snapshot. This preserves the original
+           behavior and keeps old saves loadable.
+        2. The saved schema version differs from the current one: run save
+           migration (``wod_core.migrations``) to reconcile trait data, then
+           bind to the current schema.
+        3. Same version: reconstruct the snapshot, but re-bind to the shared
+           current schema object when the two are structurally identical. This
+           saves memory and lets identity checks (``splat.schema is char.schema``)
+           succeed, while a template-extended character whose snapshot legitimately
+           differs keeps its own schema.
+        """
         schema_data = state.pop("_schema_data", None)
+        saved_version = state.pop("_schema_version", None)
         self.__dict__.update(state)
-        if schema_data:
-            self.schema = Schema(schema_data)
-        else:
-            self.schema = None
-        # Modifiers are never persisted; a loaded character always starts clean.
+        # Saves written before splat tracking existed lack this attribute.
+        if "splat_id" not in self.__dict__:
+            self.splat_id = None
+        # Temporary modifiers are never persisted (see __getstate__); a loaded
+        # character always starts clean. Set before any early return below so the
+        # attribute always exists, whichever migration path is taken.
         self.modifiers = {}
+
+        current_schema = None
+        if self.splat_id is not None:
+            try:
+                from wod_core import migrations
+                current_schema = migrations.get_current_schema(self.splat_id)
+            except Exception:
+                current_schema = None
+
+        if current_schema is None:
+            self.schema = Schema(schema_data) if schema_data is not None else None
+            return
+
+        if saved_version != current_schema.version:
+            from wod_core import migrations
+            migrations.migrate_character(self, saved_version, current_schema)
+            self.schema = current_schema
+            return
+
+        # Same version — reconstruct the snapshot, re-binding to the shared
+        # current schema when structurally identical.
+        if schema_data is None:
+            self.schema = current_schema
+        elif schema_data == current_schema.to_dict():
+            self.schema = current_schema
+        else:
+            self.schema = Schema(schema_data)
 
     def spend(self, name: str, amount: int) -> bool:
         if self.resources is None:

--- a/game/wod_core/loader.py
+++ b/game/wod_core/loader.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 
 import yaml
 
+from wod_core import migrations
 from wod_core.engine import Schema, Character
 from wod_core.resources import ResourceManager
 
@@ -95,6 +96,16 @@ class SplatLoader:
                 _apply_overrides(schema_data, resource_config, override_data["overrides"])
 
         schema = Schema(schema_data)
+        # Fall back to the manifest's version if the schema file omits one, so a
+        # single bump in either place triggers save migration.
+        if "version" not in schema_data:
+            manifest_version = manifest["splat"].get("version")
+            if manifest_version is not None:
+                schema.version = str(manifest_version)
+
+        # Register as this splat's current schema so saves written under an
+        # older schema version can be migrated onto it when loaded.
+        migrations.register_current_schema(splat_id, schema)
 
         # Load chargen config if present
         chargen_config = None
@@ -137,6 +148,7 @@ class SplatLoader:
             traits=flat_traits,
             merits_flaws=char_data.get("merits_flaws", []),
             identity=char_data.get("identity", {}),
+            splat_id=splat_id,
         )
 
         # Set up resources
@@ -178,7 +190,7 @@ class SplatLoader:
             if "overrides" in template_data:
                 overrides = template_data["overrides"]
                 # Create modified schema data
-                schema_data_copy = self._schema_to_dict(splat.schema)
+                schema_data_copy = splat.schema.to_dict()
                 _apply_overrides(schema_data_copy, splat.resource_config, overrides)
                 schema = Schema(schema_data_copy)
             else:
@@ -205,6 +217,7 @@ class SplatLoader:
             traits=flat_traits,
             merits_flaws=char_data.get("merits_flaws", []),
             identity=identity,
+            splat_id=splat_id,
         )
 
         # Attach resources
@@ -217,8 +230,3 @@ class SplatLoader:
                     pool.max = res_value
 
         return char
-
-    @staticmethod
-    def _schema_to_dict(schema: Schema) -> dict:
-        """Convert a Schema back to a raw dict for override merging."""
-        return schema.to_dict()

--- a/game/wod_core/loader.py
+++ b/game/wod_core/loader.py
@@ -104,8 +104,11 @@ class SplatLoader:
                 schema.version = str(manifest_version)
 
         # Register as this splat's current schema so saves written under an
-        # older schema version can be migrated onto it when loaded.
+        # older schema version can be migrated onto it when loaded. The resource
+        # config is registered too, so migration can rebuild a loaded character's
+        # pools onto it (adding or renaming pools the author changed).
         migrations.register_current_schema(splat_id, schema)
+        migrations.register_current_resources(splat_id, resource_config)
 
         # Load chargen config if present
         chargen_config = None

--- a/game/wod_core/migrations.py
+++ b/game/wod_core/migrations.py
@@ -1,0 +1,336 @@
+"""Save migration — reconcile saved characters against the current schema.
+
+When an author changes a splat's schema between releases (adds, removes, or
+renames traits, or changes ranges), characters saved under the old schema can
+fall out of sync with the new one: a renamed trait raises ``KeyError`` when the
+script gates on its new name, a tightened range rejects an old value, and so on.
+
+This module versions schemas and migrates saved characters onto the current
+schema when a save is loaded:
+
+* The loader registers each splat's current :class:`~wod_core.engine.Schema`
+  here at init time (``register_current_schema``).
+* Authors bump the schema's ``version`` whenever they change traits or ranges.
+  A version change is what *triggers* migration — same-version loads are left
+  untouched, so author-level overrides and template-extended characters keep
+  their custom schemas.
+* :meth:`Character.__setstate__` calls :func:`migrate_character` when a save's
+  recorded schema version differs from the registered current version.
+
+Automatic reconciliation handles the common cases with no author code: traits
+absent from the new schema are dropped, brand-new traits are added at their
+default, and out-of-range values are clamped. Renames — where a value should be
+*preserved* under a new key — need an explicit migration step
+(:func:`register_migration` / :func:`migration`), since reconciliation alone
+cannot know that ``Old`` became ``New``.
+
+By default migration is graceful: reconcilable changes are applied with logged
+warnings and surfaced through a :class:`MigrationReport` (the framework shows a
+toast on load). Set :data:`strict` to ``True`` to instead raise
+:class:`MigrationError` — with a clear, actionable message — whenever migration
+would lose or clamp data, or an author step fails.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Callable
+
+logger = logging.getLogger("wod_core.migrations")
+
+
+class MigrationError(Exception):
+    """Raised when a saved character cannot be migrated to the current schema."""
+
+
+# --- Configuration ---------------------------------------------------------
+
+#: When True, reconciliation that would drop or clamp trait data (or an author
+#: migration step that raises) aborts the load with a :class:`MigrationError`
+#: carrying a clear message, rather than warning and proceeding.
+strict: bool = False
+
+
+# --- Registry --------------------------------------------------------------
+
+# splat_id -> current Schema, populated by the loader at init time.
+_current_schemas: dict = {}
+
+# splat_id -> list of (from_version, to_version, fn) author migration steps.
+_migration_steps: dict = {}
+
+# MigrationReports produced since the last drain, surfaced after a save loads.
+_pending_reports: list = []
+
+
+def register_current_schema(splat_id: str, schema) -> None:
+    """Register a splat's current schema so loaded saves can be migrated onto it."""
+    _current_schemas[splat_id] = schema
+
+
+def get_current_schema(splat_id: str):
+    """Return the registered current schema for a splat, or ``None``."""
+    return _current_schemas.get(splat_id)
+
+
+def register_migration(
+    splat_id: str, from_version, to_version, fn: Callable[[dict], None]
+) -> None:
+    """Register an author migration step from one schema version to another.
+
+    ``fn`` receives a mutable ``state`` dict and should modify it in place. Keys:
+
+    * ``traits`` -- ``{trait_name: value}`` (rename by moving the value to a
+      new key, e.g. ``state["traits"]["New"] = state["traits"].pop("Old")``).
+    * ``merits_flaws`` -- list of merit/flaw dicts.
+    * ``identity`` -- the identity dict.
+    * ``resources`` -- ``{pool_name: current_value}`` for existing pools (you
+      may adjust values; renaming a *pool* is not handled automatically).
+    * ``version`` / ``splat_id`` -- read-only context.
+    * ``notes`` -- a list you may append human-readable messages to; they are
+      included in the migration report.
+
+    Steps are chained by exact version string (``from_version`` -> ``to_version``);
+    gaps are tolerated (automatic reconciliation covers them).
+    """
+    _migration_steps.setdefault(splat_id, []).append(
+        (str(from_version), str(to_version), fn)
+    )
+
+
+def migration(splat_id: str, from_version, to_version):
+    """Decorator form of :func:`register_migration`.
+
+    ::
+
+        @wod_core.migration("mage", "1.0", "1.1")
+        def _rename_correspondence(state):
+            if "Correspondence" in state["traits"]:
+                state["traits"]["Data"] = state["traits"].pop("Correspondence")
+    """
+
+    def decorator(fn: Callable[[dict], None]) -> Callable[[dict], None]:
+        register_migration(splat_id, from_version, to_version, fn)
+        return fn
+
+    return decorator
+
+
+def clear() -> None:
+    """Reset all registry state. Primarily for tests."""
+    _current_schemas.clear()
+    _migration_steps.clear()
+    _pending_reports.clear()
+
+
+def drain_reports() -> list:
+    """Return and clear the migration reports accumulated since the last drain.
+
+    Called from the framework's ``after_load`` hook to surface a notification.
+    """
+    reports = list(_pending_reports)
+    _pending_reports.clear()
+    return reports
+
+
+# --- Report ----------------------------------------------------------------
+
+
+@dataclass
+class MigrationReport:
+    """A record of what changed when a save was migrated onto a new schema."""
+
+    splat_id: str
+    from_version: str
+    to_version: str
+    added: list = field(default_factory=list)       # trait names added at default
+    dropped: list = field(default_factory=list)      # trait names removed
+    clamped: list = field(default_factory=list)      # (trait, old_value, new_value)
+    steps_applied: list = field(default_factory=list)  # (from_version, to_version)
+    notes: list = field(default_factory=list)         # freeform / author messages
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.added or self.dropped or self.clamped or self.steps_applied)
+
+    def summary(self) -> str:
+        """A one-line, player-friendly summary suitable for a toast."""
+        parts = []
+        if self.steps_applied:
+            parts.append(f"{len(self.steps_applied)} migration step(s)")
+        if self.added:
+            parts.append(f"{len(self.added)} trait(s) added")
+        if self.dropped:
+            parts.append(f"{len(self.dropped)} trait(s) removed")
+        if self.clamped:
+            parts.append(f"{len(self.clamped)} value(s) adjusted")
+        detail = ", ".join(parts) if parts else "no changes"
+        return (
+            f"Save updated: {self.splat_id} schema "
+            f"{self.from_version} → {self.to_version} ({detail})."
+        )
+
+
+# --- Migration -------------------------------------------------------------
+
+
+def _resolve_chain(splat_id: str, from_version: str, to_version: str) -> list:
+    """Return author migration steps chaining ``from_version`` to ``to_version``.
+
+    Matches steps by exact ``from_version``. Missing links are allowed (automatic
+    reconciliation covers them); a cycle raises :class:`MigrationError`.
+    """
+    by_from: dict = {}
+    for step in _migration_steps.get(splat_id, []):
+        by_from.setdefault(step[0], step)  # first registered step per from-version
+    chain = []
+    version = from_version
+    seen = set()
+    while version != to_version:
+        if version in seen:
+            raise MigrationError(
+                f"Cyclic migration steps for splat {splat_id!r} at version {version!r}."
+            )
+        seen.add(version)
+        step = by_from.get(version)
+        if step is None:
+            break  # no further author step — reconciliation handles the rest
+        chain.append(step)
+        version = step[1]
+    return chain
+
+
+def _resource_snapshot(char) -> dict:
+    res = getattr(char, "resources", None)
+    if res is None:
+        return {}
+    return {name: pool.current_value for name, pool in res.pools.items()}
+
+
+def _apply_resource_snapshot(char, snapshot: dict) -> None:
+    res = getattr(char, "resources", None)
+    if res is None:
+        return
+    for name, value in snapshot.items():
+        pool = res.pools.get(name)
+        if pool is not None and isinstance(value, int):
+            pool.current_value = value
+
+
+def _reconcile_traits(char, schema, report: MigrationReport) -> None:
+    """Bring ``char.traits`` into line with ``schema``: drop, clamp, add defaults."""
+    reconciled: dict = {}
+    for name, value in char.traits.items():
+        if not schema.has_trait(name):
+            report.dropped.append(name)
+            continue
+        if not isinstance(value, int):
+            new_value = schema.get_default(name)
+            report.clamped.append((name, value, new_value))
+            reconciled[name] = new_value
+            continue
+        lo, hi = schema.get_range(name)
+        if value < lo:
+            report.clamped.append((name, value, lo))
+            value = lo
+        elif value > hi:
+            report.clamped.append((name, value, hi))
+            value = hi
+        reconciled[name] = value
+
+    for name in schema.get_all_trait_names():
+        if name not in reconciled:
+            reconciled[name] = schema.get_default(name)
+            report.added.append(name)
+
+    char.traits = reconciled
+
+
+def _data_loss_message(report: MigrationReport) -> str:
+    bits = []
+    if report.dropped:
+        bits.append("removed trait(s): " + ", ".join(report.dropped))
+    if report.clamped:
+        bits.append(
+            "clamped value(s): "
+            + ", ".join(f"{n} {o}→{v}" for n, o, v in report.clamped)
+        )
+    return (
+        f"Cannot migrate {report.splat_id} save from schema "
+        f"{report.from_version} to {report.to_version} without data loss "
+        f"({'; '.join(bits)}). Register a migration step to preserve this data, "
+        f"or set wod_core.migrations.strict = False to reconcile automatically."
+    )
+
+
+def migrate_character(char, saved_version, current_schema) -> MigrationReport:
+    """Migrate a freshly-unpickled ``char`` onto ``current_schema``, in place.
+
+    Runs any registered author migration steps from ``saved_version`` to the
+    current schema version, then reconciles trait data against the new schema.
+    Returns a :class:`MigrationReport`; appends it to the pending list (for
+    ``after_load`` to surface) when it represents real changes. The caller is
+    responsible for binding ``char.schema = current_schema``.
+
+    Raises :class:`MigrationError` when :data:`strict` is set and migration
+    would lose data or an author step fails.
+    """
+    splat_id = getattr(char, "splat_id", None)
+    from_version = "0" if saved_version is None else str(saved_version)
+    to_version = current_schema.version
+    report = MigrationReport(splat_id, from_version, to_version)
+
+    # 1. Run author migration steps over a mutable state dict.
+    state = {
+        "version": from_version,
+        "splat_id": splat_id,
+        "traits": dict(getattr(char, "traits", {}) or {}),
+        "merits_flaws": list(getattr(char, "merits_flaws", []) or []),
+        "identity": dict(getattr(char, "identity", {}) or {}),
+        "resources": _resource_snapshot(char),
+        "notes": report.notes,
+    }
+
+    try:
+        chain = _resolve_chain(splat_id, from_version, to_version)
+    except MigrationError:
+        if strict:
+            raise
+        logger.warning("Migration chain unresolved for %r; reconciling instead.", splat_id)
+        report.notes.append(f"Unresolved migration chain for {splat_id!r}.")
+        chain = []
+
+    for step_from, step_to, fn in chain:
+        try:
+            fn(state)
+        except Exception as exc:  # noqa: BLE001 — surface author step failures
+            msg = (
+                f"Migration step {step_from} → {step_to} for splat "
+                f"{splat_id!r} failed: {exc}"
+            )
+            if strict:
+                raise MigrationError(msg) from exc
+            logger.warning(msg)
+            report.notes.append(msg)
+            break
+        state["version"] = step_to
+        report.steps_applied.append((step_from, step_to))
+
+    # Write author-mutated collections back onto the character.
+    char.traits = dict(state["traits"])
+    char.merits_flaws = list(state["merits_flaws"])
+    char.identity = dict(state["identity"])
+    _apply_resource_snapshot(char, state["resources"])
+
+    # 2. Reconcile trait keys/values against the current schema.
+    _reconcile_traits(char, current_schema, report)
+
+    if strict and (report.dropped or report.clamped):
+        raise MigrationError(_data_loss_message(report))
+
+    # 3. Record the report.
+    if report.changed or report.notes:
+        logger.info(report.summary())
+        _pending_reports.append(report)
+    return report

--- a/game/wod_core/migrations.py
+++ b/game/wod_core/migrations.py
@@ -9,7 +9,8 @@ This module versions schemas and migrates saved characters onto the current
 schema when a save is loaded:
 
 * The loader registers each splat's current :class:`~wod_core.engine.Schema`
-  here at init time (``register_current_schema``).
+  here at init time (``register_current_schema``), along with its current
+  resource config (``register_current_resources``).
 * Authors bump the schema's ``version`` whenever they change traits or ranges.
   A version change is what *triggers* migration — same-version loads are left
   untouched, so author-level overrides and template-extended characters keep
@@ -19,10 +20,13 @@ schema when a save is loaded:
 
 Automatic reconciliation handles the common cases with no author code: traits
 absent from the new schema are dropped, brand-new traits are added at their
-default, and out-of-range values are clamped. Renames — where a value should be
-*preserved* under a new key — need an explicit migration step
-(:func:`register_migration` / :func:`migration`), since reconciliation alone
-cannot know that ``Old`` became ``New``.
+default, and out-of-range values are clamped. Resource pools are reconciled the
+same way: the character's :class:`~wod_core.resources.ResourceManager` is rebuilt
+against the splat's current resource config, carrying current values across,
+adding pools the new config introduces, and dropping pools it removes. Renames —
+where a value should be *preserved* under a new key — need an explicit migration
+step (:func:`register_migration` / :func:`migration`), since reconciliation
+alone cannot know that ``Old`` became ``New``.
 
 By default migration is graceful: reconcilable changes are applied with logged
 warnings and surfaced through a :class:`MigrationReport` (the framework shows a
@@ -58,6 +62,9 @@ strict: bool = False
 # splat_id -> current Schema, populated by the loader at init time.
 _current_schemas: dict = {}
 
+# splat_id -> current resource config dict, populated by the loader at init time.
+_current_resources: dict = {}
+
 # splat_id -> list of (from_version, to_version, fn) author migration steps.
 _migration_steps: dict = {}
 
@@ -75,6 +82,21 @@ def get_current_schema(splat_id: str):
     return _current_schemas.get(splat_id)
 
 
+def register_current_resources(splat_id: str, resource_config: dict) -> None:
+    """Register a splat's current resource config.
+
+    On a version bump, a loaded character's :class:`ResourceManager` is rebuilt
+    from this config so that pools the author added or renamed actually exist on
+    the migrated character (see :func:`migrate_character`).
+    """
+    _current_resources[splat_id] = resource_config
+
+
+def get_current_resources(splat_id: str):
+    """Return the registered current resource config for a splat, or ``None``."""
+    return _current_resources.get(splat_id)
+
+
 def register_migration(
     splat_id: str, from_version, to_version, fn: Callable[[dict], None]
 ) -> None:
@@ -86,8 +108,14 @@ def register_migration(
       new key, e.g. ``state["traits"]["New"] = state["traits"].pop("Old")``).
     * ``merits_flaws`` -- list of merit/flaw dicts.
     * ``identity`` -- the identity dict.
-    * ``resources`` -- ``{pool_name: current_value}`` for existing pools (you
-      may adjust values; renaming a *pool* is not handled automatically).
+    * ``resources`` -- ``{pool_name: current_value}``. You may adjust values and
+      rename a pool by moving its value to a new key (e.g.
+      ``state["resources"]["Mana"] = state["resources"].pop("Quintessence")``).
+      After your steps run, the character's ResourceManager is rebuilt against
+      the splat's current resource config: keys naming a pool defined there are
+      applied, pools the config adds are created at their default, and keys
+      naming no current pool are dropped. So a renamed pool's value survives as
+      long as the new pool exists in the current ``resources.yaml``.
     * ``version`` / ``splat_id`` -- read-only context.
     * ``notes`` -- a list you may append human-readable messages to; they are
       included in the migration report.
@@ -121,6 +149,7 @@ def migration(splat_id: str, from_version, to_version):
 def clear() -> None:
     """Reset all registry state. Primarily for tests."""
     _current_schemas.clear()
+    _current_resources.clear()
     _migration_steps.clear()
     _pending_reports.clear()
 
@@ -151,6 +180,8 @@ class MigrationReport:
     steps_applied: list = field(default_factory=list)  # (from_version, to_version)
     # (trait, old_value, new_value) lowered to satisfy an inter-trait constraint
     constraint_adjusted: list = field(default_factory=list)
+    resources_added: list = field(default_factory=list)    # pool names added at default
+    resources_dropped: list = field(default_factory=list)  # (pool, lost_value)
     notes: list = field(default_factory=list)         # freeform / author messages
 
     @property
@@ -158,6 +189,7 @@ class MigrationReport:
         return bool(
             self.added or self.dropped or self.clamped
             or self.constraint_adjusted or self.steps_applied
+            or self.resources_added or self.resources_dropped
         )
 
     def summary(self) -> str:
@@ -165,10 +197,12 @@ class MigrationReport:
         parts = []
         if self.steps_applied:
             parts.append(f"{len(self.steps_applied)} migration step(s)")
-        if self.added:
-            parts.append(f"{len(self.added)} trait(s) added")
-        if self.dropped:
-            parts.append(f"{len(self.dropped)} trait(s) removed")
+        added = len(self.added) + len(self.resources_added)
+        if added:
+            parts.append(f"{added} trait(s) added")
+        dropped = len(self.dropped) + len(self.resources_dropped)
+        if dropped:
+            parts.append(f"{dropped} trait(s) removed")
         adjusted = len(self.clamped) + len(self.constraint_adjusted)
         if adjusted:
             parts.append(f"{adjusted} value(s) adjusted")
@@ -216,6 +250,13 @@ def _resource_snapshot(char) -> dict:
 
 
 def _apply_resource_snapshot(char, snapshot: dict) -> None:
+    """Write snapshot values onto the character's existing pools, in place.
+
+    Fallback used when no current resource config is registered for the splat
+    (e.g. the engine used outside a loaded game): values are written only into
+    pools that already exist, leaving the pickled ResourceManager's structure
+    untouched.
+    """
     res = getattr(char, "resources", None)
     if res is None:
         return
@@ -223,6 +264,42 @@ def _apply_resource_snapshot(char, snapshot: dict) -> None:
         pool = res.pools.get(name)
         if pool is not None and isinstance(value, int):
             pool.current_value = value
+
+
+def _rebuild_resources(char, snapshot: dict, resource_config, report: MigrationReport) -> None:
+    """Rebuild the character's ResourceManager onto the current resource config.
+
+    The pickled ResourceManager carries the *old* set of pools, so a migration
+    step that introduces or renames a pool (writing a new key into
+    ``state["resources"]``) would otherwise be silently ignored. We rebuild the
+    manager from the current config and then reconcile values:
+
+    * a pool defined by the current config takes its value from ``snapshot``
+      when present (so a renamed pool's value survives), else keeps the config
+      default (recorded in ``resources_added``);
+    * a ``snapshot`` key naming no current pool is dropped, its value lost
+      (recorded in ``resources_dropped`` and treated as data loss in strict
+      mode).
+
+    A value carried over that exceeds the pool's configured max raises that max,
+    matching how the loader applies character-specific resource values.
+    """
+    from wod_core.resources import ResourceManager
+
+    new_res = ResourceManager(dict(resource_config))
+    for name, value in snapshot.items():
+        pool = new_res.pools.get(name)
+        if pool is None:
+            report.resources_dropped.append((name, value))
+            continue
+        if isinstance(value, int):
+            pool.current_value = value
+            if value > pool.max:
+                pool.max = value
+    for name in new_res.pools:
+        if name not in snapshot:
+            report.resources_added.append(name)
+    char.resources = new_res
 
 
 def _reconcile_traits(char, schema, report: MigrationReport) -> None:
@@ -302,6 +379,11 @@ def _data_loss_message(report: MigrationReport) -> str:
             "constraint-adjusted value(s): "
             + ", ".join(f"{n} {o}→{v}" for n, o, v in report.constraint_adjusted)
         )
+    if report.resources_dropped:
+        bits.append(
+            "removed resource(s): "
+            + ", ".join(f"{n} ({v})" for n, v in report.resources_dropped)
+        )
     return (
         f"Cannot migrate {report.splat_id} save from schema "
         f"{report.from_version} to {report.to_version} without data loss "
@@ -314,10 +396,11 @@ def migrate_character(char, saved_version, current_schema) -> MigrationReport:
     """Migrate a freshly-unpickled ``char`` onto ``current_schema``, in place.
 
     Runs any registered author migration steps from ``saved_version`` to the
-    current schema version, then reconciles trait data against the new schema.
-    Returns a :class:`MigrationReport`; appends it to the pending list (for
-    ``after_load`` to surface) when it represents real changes. The caller is
-    responsible for binding ``char.schema = current_schema``.
+    current schema version, then reconciles trait data against the new schema and
+    rebuilds resource pools against the splat's current resource config. Returns
+    a :class:`MigrationReport`; appends it to the pending list (for ``after_load``
+    to surface) when it represents real changes. The caller is responsible for
+    binding ``char.schema = current_schema``.
 
     Raises :class:`MigrationError` when :data:`strict` is set and migration
     would lose data or an author step fails.
@@ -375,14 +458,26 @@ def migrate_character(char, saved_version, current_schema) -> MigrationReport:
     char.traits = dict(state["traits"])
     char.merits_flaws = list(state["merits_flaws"])
     char.identity = dict(state["identity"])
-    _apply_resource_snapshot(char, state["resources"])
+
+    # Reconcile resource pools. When the splat's current resource config is known
+    # (set by the loader), rebuild the ResourceManager onto it so pools an author
+    # added or renamed exist and carry their migrated values; otherwise fall back
+    # to writing values into the pickled manager's existing pools.
+    current_resources = get_current_resources(splat_id)
+    if current_resources is not None and getattr(char, "resources", None) is not None:
+        _rebuild_resources(char, state["resources"], current_resources, report)
+    else:
+        _apply_resource_snapshot(char, state["resources"])
 
     # 2. Reconcile trait keys/values against the current schema, then repair any
     # inter-trait constraints left violated by per-trait clamping.
     _reconcile_traits(char, current_schema, report)
     _enforce_constraints(char, current_schema, report)
 
-    if strict and (report.dropped or report.clamped or report.constraint_adjusted):
+    if strict and (
+        report.dropped or report.clamped or report.constraint_adjusted
+        or report.resources_dropped
+    ):
         raise MigrationError(_data_loss_message(report))
 
     # 3. Record the report.

--- a/game/wod_core/migrations.py
+++ b/game/wod_core/migrations.py
@@ -33,6 +33,7 @@ would lose or clamp data, or an author step fails.
 
 from __future__ import annotations
 
+import copy
 import logging
 from dataclasses import dataclass, field
 from typing import Callable
@@ -148,11 +149,16 @@ class MigrationReport:
     dropped: list = field(default_factory=list)      # trait names removed
     clamped: list = field(default_factory=list)      # (trait, old_value, new_value)
     steps_applied: list = field(default_factory=list)  # (from_version, to_version)
+    # (trait, old_value, new_value) lowered to satisfy an inter-trait constraint
+    constraint_adjusted: list = field(default_factory=list)
     notes: list = field(default_factory=list)         # freeform / author messages
 
     @property
     def changed(self) -> bool:
-        return bool(self.added or self.dropped or self.clamped or self.steps_applied)
+        return bool(
+            self.added or self.dropped or self.clamped
+            or self.constraint_adjusted or self.steps_applied
+        )
 
     def summary(self) -> str:
         """A one-line, player-friendly summary suitable for a toast."""
@@ -163,8 +169,9 @@ class MigrationReport:
             parts.append(f"{len(self.added)} trait(s) added")
         if self.dropped:
             parts.append(f"{len(self.dropped)} trait(s) removed")
-        if self.clamped:
-            parts.append(f"{len(self.clamped)} value(s) adjusted")
+        adjusted = len(self.clamped) + len(self.constraint_adjusted)
+        if adjusted:
+            parts.append(f"{adjusted} value(s) adjusted")
         detail = ", ".join(parts) if parts else "no changes"
         return (
             f"Save updated: {self.splat_id} schema "
@@ -247,6 +254,40 @@ def _reconcile_traits(char, schema, report: MigrationReport) -> None:
     char.traits = reconciled
 
 
+def _enforce_constraints(char, schema, report: MigrationReport) -> None:
+    """Repair inter-trait constraint violations introduced by reconciliation.
+
+    Per-trait range clamping can still leave a constraint unsatisfied — e.g.
+    clamping ``Arete`` down below a Sphere that ``MaxLinkedConstraint`` caps by
+    it, leaving the loaded character in a state that ``set()`` would reject. For
+    each violated constraint, lower the offending trait one step at a time until
+    it holds (bounded by the trait's own minimum). Each adjustment is recorded so
+    it is reported and, in strict mode, treated as data loss.
+    """
+    for constraint in getattr(schema, "constraints", []):
+        for trait_name in list(char.traits.keys()):
+            if not schema.has_trait(trait_name):
+                continue
+            original = char.traits[trait_name]
+            floor = schema.get_range(trait_name)[0]
+            while char.traits[trait_name] > floor:
+                try:
+                    ok, _ = constraint.validate(
+                        trait_name, char.traits[trait_name], char, schema
+                    )
+                except Exception:
+                    # Cannot evaluate this constraint (e.g. it references a trait
+                    # that no longer exists) — leave the value untouched.
+                    break
+                if ok:
+                    break
+                char.traits[trait_name] -= 1
+            if char.traits[trait_name] != original:
+                report.constraint_adjusted.append(
+                    (trait_name, original, char.traits[trait_name])
+                )
+
+
 def _data_loss_message(report: MigrationReport) -> str:
     bits = []
     if report.dropped:
@@ -255,6 +296,11 @@ def _data_loss_message(report: MigrationReport) -> str:
         bits.append(
             "clamped value(s): "
             + ", ".join(f"{n} {o}→{v}" for n, o, v in report.clamped)
+        )
+    if report.constraint_adjusted:
+        bits.append(
+            "constraint-adjusted value(s): "
+            + ", ".join(f"{n} {o}→{v}" for n, o, v in report.constraint_adjusted)
         )
     return (
         f"Cannot migrate {report.splat_id} save from schema "
@@ -289,7 +335,7 @@ def migrate_character(char, saved_version, current_schema) -> MigrationReport:
         "merits_flaws": list(getattr(char, "merits_flaws", []) or []),
         "identity": dict(getattr(char, "identity", {}) or {}),
         "resources": _resource_snapshot(char),
-        "notes": report.notes,
+        "notes": [],
     }
 
     try:
@@ -298,10 +344,15 @@ def migrate_character(char, saved_version, current_schema) -> MigrationReport:
         if strict:
             raise
         logger.warning("Migration chain unresolved for %r; reconciling instead.", splat_id)
-        report.notes.append(f"Unresolved migration chain for {splat_id!r}.")
+        state["notes"].append(f"Unresolved migration chain for {splat_id!r}.")
         chain = []
 
     for step_from, step_to, fn in chain:
+        # Snapshot before the step so that a step which mutates `state` and then
+        # raises does not leave half-applied changes behind (e.g. a rename that
+        # has popped the old key but not yet written the new one). On failure we
+        # discard the step's partial mutations and fall back to reconciliation.
+        before = copy.deepcopy(state)
         try:
             fn(state)
         except Exception as exc:  # noqa: BLE001 — surface author step failures
@@ -312,10 +363,13 @@ def migrate_character(char, saved_version, current_schema) -> MigrationReport:
             if strict:
                 raise MigrationError(msg) from exc
             logger.warning(msg)
-            report.notes.append(msg)
+            state = before  # roll back this step's partial mutations
+            state["notes"].append(msg)
             break
         state["version"] = step_to
         report.steps_applied.append((step_from, step_to))
+
+    report.notes.extend(state["notes"])
 
     # Write author-mutated collections back onto the character.
     char.traits = dict(state["traits"])
@@ -323,10 +377,12 @@ def migrate_character(char, saved_version, current_schema) -> MigrationReport:
     char.identity = dict(state["identity"])
     _apply_resource_snapshot(char, state["resources"])
 
-    # 2. Reconcile trait keys/values against the current schema.
+    # 2. Reconcile trait keys/values against the current schema, then repair any
+    # inter-trait constraints left violated by per-trait clamping.
     _reconcile_traits(char, current_schema, report)
+    _enforce_constraints(char, current_schema, report)
 
-    if strict and (report.dropped or report.clamped):
+    if strict and (report.dropped or report.clamped or report.constraint_adjusted):
         raise MigrationError(_data_loss_message(report))
 
     # 3. Record the report.

--- a/game/wod_init.rpy
+++ b/game/wod_init.rpy
@@ -18,6 +18,12 @@ init -10 python:
     wod_core.load_all_splats()
 
 label after_load:
+    ## If the save was written under an older schema version, the framework
+    ## migrates each character onto the current schema as it is unpickled.
+    ## Surface a brief notice so the player (and author) know it happened.
+    python:
+        for _wod_report in wod_core.drain_migration_reports():
+            wod_core.show_toast(_wod_report.summary(), duration=4.0)
     if store.wod_hud_visible:
         show screen resource_hud
     return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,24 @@
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _isolate_migrations():
+    """Reset the global migration registry around every test.
+
+    ``load_splat`` registers a splat's current schema in a module-level registry
+    (used by save migration). Clearing it before and after each test keeps tests
+    independent and prevents cross-test leakage of registered schemas or the
+    ``strict`` flag.
+    """
+    from wod_core import migrations
+
+    migrations.clear()
+    migrations.strict = False
+    yield
+    migrations.clear()
+    migrations.strict = False
+
+
 @pytest.fixture
 def mage_schema_data():
     """Minimal Mage schema dict for testing."""

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -392,6 +392,129 @@ class TestConstraintReconciliation:
         assert "Forces" in str(exc.value)
 
 
+# --- Resource pool reconciliation -----------------------------------------
+
+
+class TestResourceReconciliation:
+    """On a version bump the ResourceManager is rebuilt onto the splat's current
+    resource config, so pools an author adds or renames exist and carry their
+    values, and pools removed from the config are dropped."""
+
+    def test_pool_rename_via_step_is_applied(self):
+        # The bug Codex flagged: a step renames the Quintessence pool to Mana.
+        # The pickled manager has no Mana pool, but rebuilding against the
+        # current config (which defines Mana) lets the value land and gate work.
+        migrations.register_migration(
+            "s", "1", "2",
+            lambda st: st["resources"].__setitem__(
+                "Mana", st["resources"].pop("Quintessence")
+            ),
+        )
+        migrations.register_current_resources(
+            "s", {"resources": {"Mana": {"range": [0, 20], "default": 0}}}
+        )
+        char = Character(make_schema("1", ["A"]), traits={"A": 1}, splat_id="s")
+        char.resources = ResourceManager(
+            {"resources": {"Quintessence": {"range": [0, 20], "default": 10}}}
+        )
+        restored, _ = save_then_load(char, make_schema("2", ["A"]))
+        assert restored.resources.has_resource("Mana")
+        assert not restored.resources.has_resource("Quintessence")
+        assert restored.resources.current("Mana") == 10
+        # gate on the renamed pool now succeeds instead of raising KeyError.
+        assert restored.gate("Mana", ">=", 10) is True
+
+    def test_added_pool_gets_default_and_existing_value_carries(self):
+        migrations.register_current_resources(
+            "s", {"resources": {
+                "Quintessence": {"range": [0, 20], "default": 0},
+                "Paradox": {"range": [0, 20], "default": 3},
+            }},
+        )
+        char = Character(make_schema("1", ["A"]), traits={"A": 1}, splat_id="s")
+        char.resources = ResourceManager(
+            {"resources": {"Quintessence": {"range": [0, 20], "default": 5}}}
+        )
+        char.resources.pools["Quintessence"].current_value = 7
+        restored, reports = save_then_load(char, make_schema("2", ["A"]))
+        assert restored.resources.current("Quintessence") == 7   # carried over
+        assert restored.resources.current("Paradox") == 3        # new, at default
+        assert "Paradox" in reports[0].resources_added
+
+    def test_pool_removed_from_config_is_dropped(self):
+        migrations.register_current_resources(
+            "s", {"resources": {"Quintessence": {"range": [0, 20], "default": 0}}}
+        )
+        char = Character(make_schema("1", ["A"]), traits={"A": 1}, splat_id="s")
+        char.resources = ResourceManager({"resources": {
+            "Quintessence": {"range": [0, 20], "default": 5},
+            "Obsolete": {"range": [0, 10], "default": 4},
+        }})
+        restored, reports = save_then_load(char, make_schema("2", ["A"]))
+        assert restored.resources.has_resource("Quintessence")
+        assert not restored.resources.has_resource("Obsolete")
+        assert ("Obsolete", 4) in reports[0].resources_dropped
+
+    def test_carried_value_above_pool_max_raises_max(self):
+        # Mirrors the loader: a carried-over value beyond the configured max
+        # lifts the max rather than silently clamping the player's total.
+        migrations.register_current_resources(
+            "s", {"resources": {"Willpower": {"range": [0, 10], "default": 5}}}
+        )
+        char = Character(make_schema("1", ["A"]), traits={"A": 1}, splat_id="s")
+        char.resources = ResourceManager(
+            {"resources": {"Willpower": {"range": [0, 10], "default": 5}}}
+        )
+        char.resources.pools["Willpower"].current_value = 8
+        restored, _ = save_then_load(char, make_schema("2", ["A"]))
+        assert restored.resources.current("Willpower") == 8
+        assert restored.resources.pools["Willpower"].max >= 8
+
+    def test_no_registered_config_falls_back_to_existing_pools(self):
+        # Without a registered resource config, the pickled manager's pools are
+        # reused and only their values updated (legacy behavior preserved).
+        migrations.register_migration(
+            "s", "1", "2",
+            lambda st: st["resources"].__setitem__("mana", 3),
+        )
+        char = Character(make_schema("1", ["A"]), traits={"A": 1}, splat_id="s")
+        char.resources = ResourceManager(
+            {"resources": {"mana": {"range": [0, 20], "default": 10}}}
+        )
+        restored, _ = save_then_load(char, make_schema("2", ["A"]))
+        assert restored.resources.current("mana") == 3
+
+    def test_strict_raises_on_dropped_resource(self):
+        migrations.strict = True
+        migrations.register_current_resources(
+            "s", {"resources": {"Quintessence": {"range": [0, 20], "default": 0}}}
+        )
+        char = Character(make_schema("1", ["A"]), traits={"A": 1}, splat_id="s")
+        char.resources = ResourceManager({"resources": {
+            "Quintessence": {"range": [0, 20], "default": 5},
+            "Obsolete": {"range": [0, 10], "default": 4},
+        }})
+        with pytest.raises(migrations.MigrationError) as exc:
+            save_then_load(char, make_schema("2", ["A"]))
+        assert "Obsolete" in str(exc.value)
+
+    def test_strict_allows_added_resource(self):
+        # Adding a pool is not data loss, so strict mode permits it.
+        migrations.strict = True
+        migrations.register_current_resources(
+            "s", {"resources": {
+                "Quintessence": {"range": [0, 20], "default": 0},
+                "Paradox": {"range": [0, 20], "default": 3},
+            }},
+        )
+        char = Character(make_schema("1", ["A"]), traits={"A": 1}, splat_id="s")
+        char.resources = ResourceManager(
+            {"resources": {"Quintessence": {"range": [0, 20], "default": 5}}}
+        )
+        restored, _ = save_then_load(char, make_schema("2", ["A"]))
+        assert restored.resources.current("Paradox") == 3
+
+
 # --- Reports & surfacing ---------------------------------------------------
 
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,467 @@
+"""Tests for save migration across schema changes (issue #20).
+
+These exercise version-aware migration end to end via pickle round-trips, which
+is exactly how Ren'Py saves and loads characters: ``__getstate__`` stores a
+schema snapshot plus version, and ``__setstate__`` migrates the character onto
+the splat's currently-registered schema when the version has changed.
+"""
+
+import os
+import pickle
+
+import pytest
+
+import wod_core
+from wod_core import migrations
+from wod_core.engine import Character, Schema
+from wod_core.resources import ResourceManager
+
+GAME_DIR = os.path.join(os.path.dirname(__file__), "..", "game")
+
+
+# --- Helpers ---------------------------------------------------------------
+
+
+def make_schema(version, traits, rng=(0, 5), default=0):
+    """Build a single-category Schema with a flat trait list."""
+    return Schema({
+        "version": version,
+        "trait_categories": {
+            "stats": {
+                "display_name": "Stats",
+                "traits": list(traits),
+                "default": default,
+                "range": list(rng),
+            }
+        },
+    })
+
+
+def save_then_load(char, current_schema):
+    """Pickle ``char``, register ``current_schema`` as current, then unpickle.
+
+    Returns ``(restored_character, drained_reports)``.
+    """
+    blob = pickle.dumps(char)
+    migrations.register_current_schema(char.splat_id, current_schema)
+    restored = pickle.loads(blob)
+    return restored, migrations.drain_reports()
+
+
+# --- Schema versioning -----------------------------------------------------
+
+
+class TestSchemaVersion:
+    def test_version_parsed_from_data(self):
+        assert make_schema("2.0", ["A"]).version == "2.0"
+
+    def test_version_defaults_to_zero(self):
+        schema = Schema({"trait_categories": {}})
+        assert schema.version == "0"
+
+    def test_version_coerced_to_string(self):
+        # YAML may parse an unquoted 1.0 as a float.
+        assert Schema({"version": 1.5, "trait_categories": {}}).version == "1.5"
+
+    def test_to_dict_round_trips_version(self):
+        schema = make_schema("3.1", ["A", "B"], rng=(0, 7), default=1)
+        rebuilt = Schema(schema.to_dict())
+        assert rebuilt.version == "3.1"
+        assert rebuilt.get_range("A") == (0, 7)
+        assert rebuilt.get_default("B") == 1
+        assert schema.to_dict() == rebuilt.to_dict()
+
+
+# --- Registry & splat_id wiring -------------------------------------------
+
+
+class TestRegistryWiring:
+    def test_load_splat_registers_current_schema(self):
+        wod_core.init(GAME_DIR)
+        splat = wod_core.load_splat("mage")
+        registered = migrations.get_current_schema("mage")
+        assert registered is splat.schema
+        assert registered.version == "1.0"
+
+    def test_load_character_records_splat_id(self, tmp_path):
+        wod_core.init(GAME_DIR)
+        wod_core.load_splat("mage")
+        char_yaml = tmp_path / "c.yaml"
+        char_yaml.write_text(
+            "schema: mage\nidentity:\n  name: X\n"
+            "traits:\n  arete:\n    Arete: 2\nresources: {}\nmerits_flaws: []\n"
+        )
+        char = wod_core.load_character(str(char_yaml))
+        assert char.splat_id == "mage"
+
+    def test_get_current_schema_unknown_returns_none(self):
+        assert migrations.get_current_schema("nope") is None
+
+
+# --- Paths that must NOT migrate ------------------------------------------
+
+
+class TestNoMigration:
+    def test_no_splat_id_uses_snapshot(self):
+        # Pre-feature / detached characters have no splat_id and are untouched
+        # even when some splat's current schema is registered.
+        schema = make_schema("1", ["A", "B"])
+        migrations.register_current_schema("stats", make_schema("2", ["A"]))
+        char = Character(schema, traits={"A": 3, "B": 4})  # splat_id defaults None
+        restored, reports = save_then_load(char, make_schema("2", ["A"]))
+        assert restored.splat_id is None
+        assert restored.get("B") == 4  # snapshot preserved B
+        assert reports == []
+
+    def test_same_version_identical_schema_rebinds_to_current(self):
+        schema = make_schema("1", ["A", "B"])
+        char = Character(schema, traits={"A": 3}, splat_id="stats")
+        current = make_schema("1", ["A", "B"])
+        restored, reports = save_then_load(char, current)
+        # Structurally identical at the same version: bind to the shared object
+        # so identity checks (splat.schema is char.schema) succeed.
+        assert restored.schema is current
+        assert reports == []
+
+    def test_same_version_divergent_schema_keeps_snapshot(self):
+        # A template-extended character: same version, wider range. Must keep
+        # its own schema rather than being clamped to the canonical one.
+        saved = make_schema("1", ["A"], rng=(0, 10))
+        char = Character(saved, traits={"A": 9}, splat_id="stats")
+        canonical = make_schema("1", ["A"], rng=(0, 5))
+        restored, reports = save_then_load(char, canonical)
+        assert restored.schema is not canonical
+        assert restored.schema.get_range("A") == (0, 10)
+        assert restored.get("A") == 9
+        assert reports == []
+
+    def test_no_registry_reconstructs_snapshot(self):
+        schema = make_schema("1", ["A", "B"])
+        char = Character(schema, traits={"A": 2}, splat_id="stats")
+        # Nothing registered for "stats".
+        blob = pickle.dumps(char)
+        restored = pickle.loads(blob)
+        assert restored.schema is not None
+        assert restored.schema.has_trait("A")
+        assert restored.get("A") == 2
+
+
+# --- Automatic reconciliation ---------------------------------------------
+
+
+class TestAutomaticReconciliation:
+    def test_added_trait_gets_default(self):
+        char = Character(make_schema("1", ["A", "B"]), traits={"A": 2}, splat_id="s")
+        restored, reports = save_then_load(char, make_schema("2", ["A", "B", "C"], default=0))
+        assert restored.get("C") == 0
+        assert reports[0].added == ["C"]
+        assert restored.schema.has_trait("C")
+
+    def test_removed_trait_is_dropped(self):
+        char = Character(make_schema("1", ["A", "B", "C"]), traits={"C": 4}, splat_id="s")
+        restored, reports = save_then_load(char, make_schema("2", ["A", "B"]))
+        assert "C" not in restored.traits
+        assert reports[0].dropped == ["C"]
+        with pytest.raises(KeyError):
+            restored.get("C")
+
+    def test_value_above_range_is_clamped(self):
+        char = Character(make_schema("1", ["A"], rng=(0, 10)), traits={"A": 8}, splat_id="s")
+        restored, reports = save_then_load(char, make_schema("2", ["A"], rng=(0, 5)))
+        assert restored.get("A") == 5
+        assert reports[0].clamped == [("A", 8, 5)]
+
+    def test_value_below_range_is_clamped(self):
+        char = Character(make_schema("1", ["A"], rng=(0, 5)), traits={"A": 0}, splat_id="s")
+        restored, reports = save_then_load(char, make_schema("2", ["A"], rng=(2, 5)))
+        assert restored.get("A") == 2
+        assert reports[0].clamped == [("A", 0, 2)]
+
+    def test_rebinds_to_current_schema_object(self):
+        char = Character(make_schema("1", ["A"]), traits={"A": 1}, splat_id="s")
+        current = make_schema("2", ["A", "B"])
+        restored, _ = save_then_load(char, current)
+        assert restored.schema is current
+
+    def test_combined_changes_report(self):
+        char = Character(
+            make_schema("1", ["A", "B", "Old"], rng=(0, 10)),
+            traits={"A": 9, "Old": 3},
+            splat_id="s",
+        )
+        restored, reports = save_then_load(char, make_schema("2", ["A", "B", "New"], rng=(0, 5)))
+        report = reports[0]
+        assert report.clamped == [("A", 9, 5)]
+        assert report.dropped == ["Old"]
+        assert report.added == ["New"]
+        assert report.from_version == "1"
+        assert report.to_version == "2"
+
+
+# --- Author-registered migration steps ------------------------------------
+
+
+class TestAuthorMigrations:
+    def test_rename_preserves_value(self):
+        migrations.register_migration(
+            "s", "1", "2",
+            lambda st: st["traits"].update({"New": st["traits"].pop("Old")}),
+        )
+        char = Character(make_schema("1", ["Old", "B"]), traits={"Old": 4}, splat_id="s")
+        restored, reports = save_then_load(char, make_schema("2", ["New", "B"]))
+        assert restored.get("New") == 4
+        assert "Old" not in restored.traits
+        # The value was preserved, so "New" is not a default-added trait.
+        assert reports[0].added == []
+        assert reports[0].steps_applied == [("1", "2")]
+
+    def test_decorator_registration(self):
+        @migrations.migration("s", "1", "2")
+        def _rename(state):  # noqa: ANN001
+            state["traits"]["New"] = state["traits"].pop("Old", 0)
+
+        char = Character(make_schema("1", ["Old"]), traits={"Old": 5}, splat_id="s")
+        restored, _ = save_then_load(char, make_schema("2", ["New"]))
+        assert restored.get("New") == 5
+
+    def test_migration_chain_applies_in_order(self):
+        order = []
+        migrations.register_migration("s", "1", "2", lambda st: order.append("1->2"))
+        migrations.register_migration("s", "2", "3", lambda st: order.append("2->3"))
+        char = Character(make_schema("1", ["A"]), traits={"A": 1}, splat_id="s")
+        _, reports = save_then_load(char, make_schema("3", ["A"]))
+        assert order == ["1->2", "2->3"]
+        assert reports[0].steps_applied == [("1", "2"), ("2", "3")]
+
+    def test_chain_transforms_value_through_steps(self):
+        migrations.register_migration("s", "1", "2", lambda st: st["traits"].__setitem__("A", st["traits"]["A"] + 1))
+        migrations.register_migration("s", "2", "3", lambda st: st["traits"].__setitem__("A", st["traits"]["A"] * 2))
+        char = Character(make_schema("1", ["A"], rng=(0, 20)), traits={"A": 2}, splat_id="s")
+        restored, _ = save_then_load(char, make_schema("3", ["A"], rng=(0, 20)))
+        assert restored.get("A") == (2 + 1) * 2
+
+    def test_missing_link_falls_back_to_reconciliation(self):
+        # A step exists for 1->2 but the target is 3; reconciliation covers 2->3.
+        migrations.register_migration(
+            "s", "1", "2",
+            lambda st: st["traits"].update({"New": st["traits"].pop("Old")}),
+        )
+        char = Character(make_schema("1", ["Old"]), traits={"Old": 3}, splat_id="s")
+        restored, reports = save_then_load(char, make_schema("3", ["New", "Extra"]))
+        assert restored.get("New") == 3
+        assert reports[0].added == ["Extra"]
+        assert reports[0].steps_applied == [("1", "2")]
+
+    def test_step_can_adjust_resources(self):
+        migrations.register_migration(
+            "s", "1", "2",
+            lambda st: st["resources"].__setitem__("mana", st["resources"]["mana"] // 2),
+        )
+        char = Character(make_schema("1", ["A"]), traits={"A": 1}, splat_id="s")
+        char.resources = ResourceManager({"resources": {"mana": {"range": [0, 20], "default": 10}}})
+        assert char.resources.current("mana") == 10
+        restored, _ = save_then_load(char, make_schema("2", ["A"]))
+        assert restored.resources.current("mana") == 5
+
+    def test_failing_step_warns_and_proceeds_when_not_strict(self):
+        def _boom(state):
+            raise RuntimeError("kaboom")
+
+        migrations.register_migration("s", "1", "2", _boom)
+        char = Character(make_schema("1", ["A"]), traits={"A": 2}, splat_id="s")
+        # Should not raise; reconciliation still runs.
+        restored, reports = save_then_load(char, make_schema("2", ["A"]))
+        assert restored.get("A") == 2
+        assert any("kaboom" in n for n in reports[0].notes)
+
+    def test_cyclic_chain_warns_and_reconciles_when_not_strict(self):
+        migrations.register_migration("s", "1", "2", lambda st: None)
+        migrations.register_migration("s", "2", "1", lambda st: None)
+        char = Character(make_schema("1", ["A"]), traits={"A": 1}, splat_id="s")
+        # 1 -> 3 with a 1<->2 cycle: chain resolution detects the cycle, warns,
+        # and reconciliation handles the rest.
+        restored, reports = save_then_load(char, make_schema("3", ["A"]))
+        assert restored.get("A") == 1
+        assert any("Unresolved" in n for n in reports[0].notes)
+
+
+# --- Strict mode -----------------------------------------------------------
+
+
+class TestStrictMode:
+    def test_strict_raises_on_dropped_trait(self):
+        migrations.strict = True
+        char = Character(make_schema("1", ["A", "B", "C"]), traits={"C": 4}, splat_id="s")
+        with pytest.raises(migrations.MigrationError) as exc:
+            save_then_load(char, make_schema("2", ["A", "B"]))
+        assert "C" in str(exc.value)
+        assert "data loss" in str(exc.value)
+
+    def test_strict_raises_on_clamp(self):
+        migrations.strict = True
+        char = Character(make_schema("1", ["A"], rng=(0, 10)), traits={"A": 9}, splat_id="s")
+        with pytest.raises(migrations.MigrationError) as exc:
+            save_then_load(char, make_schema("2", ["A"], rng=(0, 5)))
+        assert "9→5" in str(exc.value) or "9" in str(exc.value)
+
+    def test_strict_raises_on_step_failure(self):
+        migrations.strict = True
+
+        def _boom(state):
+            raise ValueError("nope")
+
+        migrations.register_migration("s", "1", "2", _boom)
+        char = Character(make_schema("1", ["A"]), traits={"A": 1}, splat_id="s")
+        with pytest.raises(migrations.MigrationError):
+            save_then_load(char, make_schema("2", ["A"]))
+
+    def test_strict_allows_clean_migration(self):
+        # Adding traits is not data loss, so strict mode permits it.
+        migrations.strict = True
+        char = Character(make_schema("1", ["A"]), traits={"A": 1}, splat_id="s")
+        restored, _ = save_then_load(char, make_schema("2", ["A", "B"]))
+        assert restored.get("B") == 0
+
+
+# --- Reports & surfacing ---------------------------------------------------
+
+
+class TestReports:
+    def test_summary_mentions_versions(self):
+        char = Character(make_schema("1", ["A"]), traits={"A": 1}, splat_id="mage")
+        _, reports = save_then_load(char, make_schema("2.0", ["A", "B"]))
+        summary = reports[0].summary()
+        assert "mage" in summary
+        assert "1 → 2.0" in summary
+        assert "trait(s) added" in summary
+
+    def test_drain_clears_pending(self):
+        char = Character(make_schema("1", ["A"]), traits={"A": 1}, splat_id="s")
+        save_then_load(char, make_schema("2", ["A", "B"]))
+        # save_then_load already drained once; a second drain is empty.
+        assert migrations.drain_reports() == []
+
+    def test_no_report_when_nothing_changed(self):
+        # Same trait set, only the version bumped: no added/dropped/clamped.
+        char = Character(make_schema("1", ["A", "B"]), traits={"A": 1}, splat_id="s")
+        _, reports = save_then_load(char, make_schema("2", ["A", "B"]))
+        assert reports == []
+
+    def test_drain_via_public_api(self):
+        char = Character(make_schema("1", ["A"]), traits={"A": 1}, splat_id="s")
+        blob = pickle.dumps(char)
+        migrations.register_current_schema("s", make_schema("2", ["A", "B"]))
+        pickle.loads(blob)
+        reports = wod_core.drain_migration_reports()
+        assert len(reports) == 1
+
+
+# --- Backward compatibility ------------------------------------------------
+
+
+class TestBackwardCompat:
+    def test_legacy_state_without_splat_id_or_version(self):
+        # Emulate a save written before this feature: snapshot only, no
+        # splat_id and no _schema_version. It must load and stay on its snapshot
+        # even if some splat's schema happens to be registered.
+        migrations.register_current_schema("stats", make_schema("9", ["A"]))
+        old_schema = make_schema("0", ["A", "B"])
+        state = {
+            "traits": {"A": 2, "B": 3},
+            "merits_flaws": [],
+            "identity": {"name": "Legacy"},
+            "resources": None,
+            "_schema_data": old_schema.to_dict(),
+        }
+        char = Character.__new__(Character)
+        char.__setstate__(state)
+        assert char.splat_id is None
+        assert char.get("A") == 2
+        assert char.get("B") == 3  # not dropped despite registered schema
+
+    def test_existing_pickle_round_trip_still_works(self, mage_schema_data):
+        # Mirrors test_engine.TestCharacterSerialization with no registry.
+        schema = Schema(mage_schema_data)
+        char = Character(schema, traits={"Strength": 3, "Arete": 3, "Forces": 2})
+        restored = pickle.loads(pickle.dumps(char))
+        assert restored.get("Strength") == 3
+        assert restored.gate("Strength", ">=", 3) is True
+
+
+# --- Idempotence -----------------------------------------------------------
+
+
+class TestIdempotence:
+    def test_migration_is_not_reapplied_after_first_load(self):
+        char = Character(make_schema("1", ["A"]), traits={"A": 1}, splat_id="s")
+        current = make_schema("2", ["A", "B"])
+        restored, reports = save_then_load(char, current)
+        assert len(reports) == 1
+        # Re-save the migrated character and load again under the same schema:
+        # versions now match, so no further migration occurs.
+        restored2, reports2 = save_then_load(restored, current)
+        assert reports2 == []
+        assert restored2.schema is current
+        assert restored2.get("B") == 0
+
+
+# --- Regression: the bug from issue #20 -----------------------------------
+
+
+class TestRenameRegression:
+    """A renamed trait used to break saves: gating on the new name raised
+    KeyError because the loaded character carried the old schema. With a
+    migration step the value is preserved and gating works."""
+
+    def test_gate_on_renamed_trait_after_migration(self):
+        migrations.register_migration(
+            "mage", "1.0", "1.1",
+            lambda st: st["traits"].update({"Data": st["traits"].pop("Correspondence")}),
+        )
+        v1 = make_schema("1.0", ["Correspondence", "Forces"])
+        char = Character(v1, traits={"Correspondence": 3}, splat_id="mage")
+        restored, _ = save_then_load(char, make_schema("1.1", ["Data", "Forces"]))
+        # The new name works and carries the old value.
+        assert restored.gate("Data", ">=", 3) is True
+        # The old name is gone from the current schema.
+        assert restored.schema.has_trait("Correspondence") is False
+
+    def test_without_step_value_is_lost_but_load_succeeds(self):
+        # No migration step: the rename looks like drop+add, so the value resets
+        # to default rather than crashing the load (graceful degradation).
+        v1 = make_schema("1.0", ["Correspondence", "Forces"])
+        char = Character(v1, traits={"Correspondence": 3}, splat_id="mage")
+        restored, reports = save_then_load(char, make_schema("1.1", ["Data", "Forces"]))
+        assert restored.get("Data") == 0
+        assert "Correspondence" in reports[0].dropped
+        assert "Data" in reports[0].added
+
+
+# --- Real Mage schema integration -----------------------------------------
+
+
+class TestRealSchemaIntegration:
+    def test_mage_save_migrates_when_sphere_added(self, tmp_path):
+        wod_core.init(GAME_DIR)
+        splat = wod_core.load_splat("mage")
+        char_yaml = tmp_path / "elena.yaml"
+        char_yaml.write_text(
+            "schema: mage\nidentity:\n  name: Elena\n"
+            "traits:\n  arete:\n    Arete: 3\n  spheres:\n    Forces: 3\n"
+            "resources:\n  quintessence: 5\nmerits_flaws: []\n"
+        )
+        char = wod_core.load_character(str(char_yaml))
+        blob = pickle.dumps(char)
+
+        # Author adds a new sphere and bumps the version.
+        new_data = splat.schema.to_dict()
+        new_data["version"] = "1.1"
+        new_data["trait_categories"]["spheres"]["traits"].append("Data")
+        migrations.register_current_schema("mage", Schema(new_data))
+
+        restored = pickle.loads(blob)
+        reports = migrations.drain_reports()
+        assert restored.get("Data") == 0
+        assert restored.get("Forces") == 3  # existing data preserved
+        assert restored.resources.current("quintessence") == 5
+        assert reports and "Data" in reports[0].added

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -284,6 +284,20 @@ class TestAuthorMigrations:
         assert restored.get("A") == 1
         assert any("Unresolved" in n for n in reports[0].notes)
 
+    def test_failed_step_rolls_back_partial_mutation(self):
+        # A step that pops the old key and then fails must not leave the data
+        # half-migrated: the value should survive via rollback + reconciliation.
+        def _bad_rename(state):
+            state["traits"]["TEMP"] = state["traits"].pop("Old")
+            raise RuntimeError("transform failed")
+
+        migrations.register_migration("s", "1", "2", _bad_rename)
+        char = Character(make_schema("1", ["Old", "B"]), traits={"Old": 4, "B": 2}, splat_id="s")
+        restored, reports = save_then_load(char, make_schema("2", ["Old", "B"]))
+        assert restored.get("Old") == 4          # not lost to the partial pop
+        assert "TEMP" not in restored.traits      # partial mutation discarded
+        assert any("transform failed" in n for n in reports[0].notes)
+
 
 # --- Strict mode -----------------------------------------------------------
 
@@ -321,6 +335,61 @@ class TestStrictMode:
         char = Character(make_schema("1", ["A"]), traits={"A": 1}, splat_id="s")
         restored, _ = save_then_load(char, make_schema("2", ["A", "B"]))
         assert restored.get("B") == 0
+
+
+# --- Inter-trait constraint reconciliation ---------------------------------
+
+
+class TestConstraintReconciliation:
+    """A version bump that lowers a depended-on trait must not leave the
+    character violating an inter-trait constraint (e.g. Sphere <= Arete)."""
+
+    @staticmethod
+    def _schema(version, arete_range, sphere_range):
+        return Schema({
+            "version": version,
+            "trait_categories": {
+                "arete": {"display_name": "Arete", "traits": ["Arete"],
+                          "default": 1, "range": list(arete_range)},
+                "spheres": {"display_name": "Spheres", "traits": ["Forces", "Prime"],
+                            "default": 0, "range": list(sphere_range)},
+            },
+            "trait_constraints": [{
+                "type": "max_linked", "target_category": "spheres",
+                "limited_by": "Arete", "rule": "No Sphere may exceed Arete",
+            }],
+        })
+
+    def test_sphere_clamped_when_arete_narrowed(self):
+        v1 = self._schema("1", (1, 10), (0, 10))
+        char = Character(v1, traits={"Arete": 5, "Forces": 5}, splat_id="m")
+        v2 = self._schema("2", (1, 3), (0, 10))  # Arete capped at 3 now
+        restored, reports = save_then_load(char, v2)
+        assert restored.get("Arete") == 3                       # range-clamped
+        assert restored.get("Forces") == 3                      # constraint-repaired
+        assert ("Forces", 5, 3) in reports[0].constraint_adjusted
+        # The loaded character is internally consistent: set() accepts it.
+        restored.set("Forces", 3)
+
+    def test_range_clamp_without_constraint_violation(self):
+        # Forces is range-clamped, but Arete stays high enough that Sphere<=Arete
+        # still holds, so no constraint repair occurs (only the range clamp).
+        v1 = self._schema("1", (1, 10), (0, 10))
+        char = Character(v1, traits={"Arete": 8, "Forces": 7}, splat_id="m")
+        v2 = self._schema("2", (1, 10), (0, 5))
+        restored, reports = save_then_load(char, v2)
+        assert restored.get("Forces") == 5                 # range-clamped
+        assert reports[0].clamped == [("Forces", 7, 5)]
+        assert reports[0].constraint_adjusted == []         # constraint untouched
+
+    def test_strict_raises_on_constraint_adjustment(self):
+        migrations.strict = True
+        v1 = self._schema("1", (1, 10), (0, 10))
+        char = Character(v1, traits={"Arete": 5, "Forces": 5}, splat_id="m")
+        v2 = self._schema("2", (1, 3), (0, 10))
+        with pytest.raises(migrations.MigrationError) as exc:
+            save_then_load(char, v2)
+        assert "Forces" in str(exc.value)
 
 
 # --- Reports & surfacing ---------------------------------------------------


### PR DESCRIPTION
Closes #20.

## Problem

When an author changed a splat's schema between releases — renaming a trait, adding/removing one, or narrowing a range — existing save files broke. A saved `Character` pickled a **snapshot of its old schema** and reconstructed that on load, so the loaded character diverged from the game's current schema: gating on a renamed trait raised `KeyError`, advancing past a tightened range failed, and new traits were missing entirely. The design spec had listed this as out of scope for v1.

## Approach

Schemas now carry a `version`, and characters record their `splat_id` and the version they were saved under. On load (`Character.__setstate__`), if the saved version differs from the splat's currently-registered schema version, the character is migrated onto the new schema.

**Automatic reconciliation** (no author code needed):
| Change | On load |
|--------|---------|
| Trait added | set to schema default |
| Trait removed | dropped |
| Range narrowed | out-of-range values clamped, then inter-trait constraints repaired |
| Range widened | unchanged |
| Resource pool added | created at its configured default |
| Resource pool removed | dropped (lost value reported) |

**Author migration steps** preserve renamed values (reconciliation alone can't tell a rename from a drop+add):

```python
@wod_core.migration("mage", "1.0", "1.1")
def rename_correspondence(state):
    if "Correspondence" in state["traits"]:
        state["traits"]["Data"] = state["traits"].pop("Correspondence")
```

Steps chain across versions (`1.0→1.1→2.0`), with reconciliation filling any gaps. Steps may also rename resource pools (`state["resources"]["Mana"] = state["resources"].pop("Quintessence")`); after the steps run, the character's `ResourceManager` is **rebuilt against the splat's current resource config** so the renamed/added pool actually exists and carries its value. A step that mutates `state` and then raises is **rolled back** to its pre-step snapshot, so a half-applied rename can't lose data — reconciliation then takes over.

**Graceful by default**: migration warns + reconciles and surfaces a toast in `after_load`. Opt-in `wod_core.migrations.strict = True` raises a clear `MigrationError` describing exactly what couldn't be migrated (dropped/clamped traits, constraint-adjusted values, or dropped resource pools).

## Why this is safe for existing saves & overrides

- **Version bump is the trigger.** Same-version loads are left untouched, so author-level overrides (appended traits) and template-extended characters (e.g. the archmage's wider Sphere range) keep their custom schemas.
- **Pre-versioning saves** have no `splat_id`, so they fall back to the original snapshot behavior and keep loading unchanged.
- **Resources without a registered config** (engine used outside a loaded game) fall back to value-only application onto existing pools, leaving the pickled manager's structure untouched.
- **Bonus fix:** same-version loads now re-bind to the shared schema object when structurally identical, fixing `character_sheet.rpy`'s `splat.schema is char.schema` lookup that silently fell back to auto-generated tabs after any load.

## Changes

- **`engine.py`** — `Schema.version` + `Schema.to_dict()`; `Character.splat_id`; migration-aware `__getstate__`/`__setstate__`.
- **`migrations.py`** (new) — registry (schema + resource config), author migration steps, reconciliation, inter-trait **constraint repair** after clamping, **failed-step rollback**, **resource-pool rebuild** against the current config, `MigrationReport`, `strict` mode.
- **`loader.py` / `chargen.py`** — register each splat's current schema **and resource config**; thread `splat_id` into characters; dropped the duplicated `_schema_to_dict` (now `Schema.to_dict`).
- **`wod_init.rpy`** — `after_load` surfaces a migration toast.
- **`schema.yaml`** — `version: "1.0"`.
- **Docs** — Author Guide "Schema Versioning & Save Migration" section, README feature bullet, internal design-spec update.

## Tests

`tests/test_migrations.py` adds **50 tests**: schema versioning, registry/`splat_id` wiring, the no-migration paths (no splat_id / same version / divergent snapshot / no registry), automatic reconciliation (add/drop/clamp), inter-trait constraint repair after clamping, author steps (rename, decorator, chains, missing links, resource adjustment, failure handling + rollback, cycles), resource-pool rebuild (rename/add/drop, value carry-over, max raise, no-config fallback, strict-mode drop), strict mode, reports/surfacing, backward compatibility, idempotence, and a regression test for the renamed-trait gating bug from the issue.

Full suite: **216 passed** (166 pre-existing + 50 new).

> [!NOTE]
> The framework targets Ren'Py but has no Ren'Py available in CI, so the `.rpy` `after_load` change is verified by structure/review rather than a live run. The Python engine path is exercised end-to-end via pickle round-trips, which is exactly how Ren'Py saves/loads characters.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrC15mivcuHRapLNULqav4)_