### PR TITLE
Add "The Hollow Vigil" — a 5-scene Mage demo chronicle with image placeholders + manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ You write your story in Ren'Py. The framework handles character stats, resource 
    renpy.sh wod_vn_framework/game/
    ```
 
-The demo loads a pre-built Mage character (Elena Vasquez) and walks through stat-gated choices, resource spending, and outcome branching.
+The title screen offers two demos:
+
+- **The Hollow Vigil** — a 5-scene branching Mage chronicle (Soraya Mir, Order of Hermes) with multiple endings, image placeholders, and an art manifest. It exercises every core feature: stat gating, merits/flaws, the Quintessence–Paradox Wheel, Willpower/Health, mid-story advancement, and toasts. See [docs/demo-chronicle.md](docs/demo-chronicle.md). It plays start-to-finish with **no art assets** — every image renders a labelled placeholder until you supply the real file.
+- **Elena vs. the Technocratic Ward** — a short single-scene feature demo (Elena Vasquez) walking through stat-gated choices, resource spending, and outcome branching.
 
 ### Start a new game project
 
@@ -61,7 +64,9 @@ Click "Use this template" on GitHub to create a new repo, then follow the steps 
 ```
 wod_vn_framework/
   game/
-    script.rpy              # Your game script (demo included)
+    script.rpy              # Demo launcher (chronicle + feature demo)
+    chronicle.rpy           # "The Hollow Vigil" — 5-scene demo chronicle
+    images.rpy              # Art registry: real files, or auto placeholders
     wod_init.rpy            # Framework bootstrap — loads engine and splats
     wod_core/               # Python engine
       __init__.py           #   Public API (load_character, chargen, show_hud, etc.)
@@ -85,13 +90,17 @@ wod_vn_framework/
         chargen.yaml        #   Chargen modes, traditions, archetypes, merits/flaws
         templates/          #   Pre-built character templates
     demo/
-      elena.yaml            # Demo character file
+      elena.yaml            # Feature-demo character
+      soraya.yaml           # Chronicle protagonist (Soraya Mir)
+    images/
+      manifest.yaml         # Canonical art manifest for the chronicle
     themes/
       gothic/               # Default dark theme assets
       neutral/              # Fallback neutral theme
   tests/                    # pytest test suite
   docs/
     author-guide.md         # Complete reference for writing games with the framework
+    demo-chronicle.md       # Walkthrough + image manifest for "The Hollow Vigil"
 ```
 
 ## For Authors

--- a/docs/author-guide.md
+++ b/docs/author-guide.md
@@ -2,6 +2,11 @@
 
 A complete reference for writing World of Darkness visual novels with the framework.
 
+> **Looking for a worked example?** [`docs/demo-chronicle.md`](demo-chronicle.md)
+> walks through *The Hollow Vigil* — a 5-scene branching Mage chronicle
+> (`game/chronicle.rpy`) that exercises every feature in this guide, with image
+> placeholders and an art manifest.
+
 ---
 
 ## Table of Contents

--- a/docs/demo-chronicle.md
+++ b/docs/demo-chronicle.md
@@ -48,7 +48,7 @@ The ending is determined by the player's choices and resource state.
 |-------|-------|--------------|------------------------------|
 | 1 | **The Summons** | Soraya learns Vance is missing and decides how to begin. | `load_character`, `set_active`, `show_hud`, `show_toast`, identity interpolation, **Flaw** check (`has("Nightmares")`), gates on **Background** (`Mentor`) and **Ability** (`Investigation`), a hidden premium gate (`Correspondence >= 3`). |
 | 2 | **The Sanctum** | Searching Vance's library for what he did and why. | **Spirit** gate reveals the familiar Corvin; investigation menu gated on `Prime`/`Occult`/`Investigation`/`Awareness`; **Quintessence spend** + small **Paradox gain** (the Wheel); one-time **`advance("Cosmology")`** with a toast. |
-| 3 | **The Breach** | The Node tears open; Soraya must stabilise it. | **Merit** check (`has("Natural Channel")`) to **gain Quintessence** from the Node; stabilise menu gated on `Forces`/`Spirit` (+ hidden `Correspondence`); **spend** Quintessence/Willpower/Health; **Paradox backlash** branch; spend-failure fallback. |
+| 3 | **The Breach** | The Node tears open; Soraya must stabilise it. | **Resonance** gate (`Static >= 2`); **Merit** check (`has("Natural Channel")`) to **gain Quintessence** from the Node; stabilise menu gated on `Forces`/`Spirit` (+ hidden `Correspondence`); **spend** Quintessence/Willpower/Health; **Paradox backlash** branch; spend-failure fallback. |
 | 4 | **The Vigil** *(climax)* | Confront the Paradox-touched Vance and choose his fate. | Compound gates (`Spirit >= 2 and Prime >= 2`), `Prime`, `Mentor` bond, hidden `Forces >= 4`; Willpower/Quintessence spends with insufficient-resource fallbacks; sets the ending flag `hv_mentor_fate`. |
 | 5 | **Aftermath** | Resolution keyed to choices, plus a final-state readout. | Four-way ending branch (`reconciled`/`released`/`anchored`/`fled`), reads back final resources & advanced traits, `hide_hud`. |
 
@@ -61,7 +61,7 @@ Soraya's sheet (`demo/soraya.yaml`) is tuned so the **main path** of every scene
 is reachable, while two **premium gates** stay deliberately out of reach to show
 how gating *hides* choices rather than failing them:
 
-- Reachable: `Forces 3`, `Prime 2`, `Spirit 2`, `Awareness 3`, `Occult 3`, `Investigation 3`, `Mentor 3`, `Avatar 3`, `Node 2`.
+- Reachable: `Forces 3`, `Prime 2`, `Spirit 2`, `Static 2` (Resonance), `Awareness 3`, `Occult 3`, `Investigation 3`, `Mentor 3`, `Avatar 3`, `Node 2`.
 - Hidden for Soraya: `Correspondence >= 3` (she has 1) and `Forces >= 4` (she has 3).
 
 Swap in a character with higher `Correspondence` or `Forces` and new options

--- a/docs/demo-chronicle.md
+++ b/docs/demo-chronicle.md
@@ -1,0 +1,125 @@
+# Demo Chronicle — *The Hollow Vigil*
+
+A complete, branching **Mage: The Ascension** short story built on the WoD VN
+Framework. It is meant as a worked example for authors: a chronicle long enough
+to show real structure (5 scenes, multiple endings) while exercising every core
+framework feature. It ships **playable with zero art** — every background,
+sprite, and CG renders a labelled placeholder until you supply the real file.
+
+- **Script:** [`game/chronicle.rpy`](../game/chronicle.rpy)
+- **Protagonist:** [`game/demo/soraya.yaml`](../game/demo/soraya.yaml) — Soraya Mir, Order of Hermes
+- **Art registry / placeholders:** [`game/images.rpy`](../game/images.rpy)
+- **Image manifest (canonical):** [`game/images/manifest.yaml`](../game/images/manifest.yaml)
+
+---
+
+## Running it
+
+```bash
+renpy.sh game/
+```
+
+From the title screen, choose **"The Hollow Vigil — a Mage demo chronicle (5
+scenes)."** (The short single-scene feature demo, *Elena vs. the Technocratic
+Ward*, is still available from the same launcher.)
+
+You can play start-to-finish immediately — placeholders stand in for any missing
+art. See [Supplying art](#supplying-art) to drop in real assets.
+
+---
+
+## Synopsis
+
+Soraya Mir's mentor, Magister Aurelio Vance, has missed the new-moon vigil for
+the first time in thirty years and his wards have gone dark. Soraya follows the
+trail to his chantry and the failing Node beneath it, where she finds that Vance
+attempted the *Hollow Vigil* — holding a dying Node open by sheer will — and that
+Paradox has claimed him for it. She must stabilise the breach and then decide her
+mentor's fate: sever the working, anchor him with her own Pattern, reach him
+through their bond, or flee.
+
+The ending is determined by the player's choices and resource state.
+
+---
+
+## Scene breakdown & features demonstrated
+
+| Scene | Title | What happens | Framework features exercised |
+|-------|-------|--------------|------------------------------|
+| 1 | **The Summons** | Soraya learns Vance is missing and decides how to begin. | `load_character`, `set_active`, `show_hud`, `show_toast`, identity interpolation, **Flaw** check (`has("Nightmares")`), gates on **Background** (`Mentor`) and **Ability** (`Investigation`), a hidden premium gate (`Correspondence >= 3`). |
+| 2 | **The Sanctum** | Searching Vance's library for what he did and why. | **Spirit** gate reveals the familiar Corvin; investigation menu gated on `Prime`/`Occult`/`Investigation`/`Awareness`; **Quintessence spend** + small **Paradox gain** (the Wheel); one-time **`advance("Cosmology")`** with a toast. |
+| 3 | **The Breach** | The Node tears open; Soraya must stabilise it. | **Merit** check (`has("Natural Channel")`) to **gain Quintessence** from the Node; stabilise menu gated on `Forces`/`Spirit` (+ hidden `Correspondence`); **spend** Quintessence/Willpower/Health; **Paradox backlash** branch; spend-failure fallback. |
+| 4 | **The Vigil** *(climax)* | Confront the Paradox-touched Vance and choose his fate. | Compound gates (`Spirit >= 2 and Prime >= 2`), `Prime`, `Mentor` bond, hidden `Forces >= 4`; Willpower/Quintessence spends with insufficient-resource fallbacks; sets the ending flag `hv_mentor_fate`. |
+| 5 | **Aftermath** | Resolution keyed to choices, plus a final-state readout. | Four-way ending branch (`reconciled`/`released`/`anchored`/`fled`), reads back final resources & advanced traits, `hide_hud`. |
+
+Every menu includes an unconditional fallback choice, so the chronicle is always
+completable regardless of the protagonist's sheet.
+
+### Why these stats?
+
+Soraya's sheet (`demo/soraya.yaml`) is tuned so the **main path** of every scene
+is reachable, while two **premium gates** stay deliberately out of reach to show
+how gating *hides* choices rather than failing them:
+
+- Reachable: `Forces 3`, `Prime 2`, `Spirit 2`, `Awareness 3`, `Occult 3`, `Investigation 3`, `Mentor 3`, `Avatar 3`, `Node 2`.
+- Hidden for Soraya: `Correspondence >= 3` (she has 1) and `Forces >= 4` (she has 3).
+
+Swap in a character with higher `Correspondence` or `Forces` and new options
+appear — a good way to feel the gating system at work.
+
+---
+
+## Supplying art
+
+The chronicle references images by short logical names (e.g. `sanctum_library`,
+`soraya focused`). Each name is registered in `game/images.rpy`, which checks
+whether the real file exists and, if not, draws a self-describing placeholder:
+
+```
+   if renpy.loadable(target):  use the file
+   else:                       draw a labelled placeholder
+```
+
+So to ship real art, **just drop a file at the path in the manifest** — no code
+change is needed. The logical name is decoupled from the file path, so you can
+organise `game/images/` however you like; only the paths in `game/images.rpy`
+(and the manifest) need to match where you put the files.
+
+- Backgrounds & CGs: full-frame at the project resolution **1920×1080**.
+- Sprites: PNG with transparency, roughly **560×1040**, full-figure (the script
+  shows them with the built-in `left` / `center` / `right` positions, so they are
+  bottom-aligned).
+
+If you add or remove assets, keep `WOD_CHRONICLE_ART` in `game/images.rpy` and
+`game/images/manifest.yaml` in sync (the two are cross-checked in spirit; the
+manifest is the canonical spec).
+
+---
+
+## Image manifest
+
+18 assets. Until supplied, each renders as an on-screen placeholder.
+
+| # | Image name | Type | File | Size | Scenes | Art direction |
+|---|------------|------|------|------|--------|---------------|
+| 1 | `apartment_night` | Background | `images/bg/apartment_night.png` | 1920x1080 | 1 | Soraya's cramped Hermetic study at night: candle-lit desk, brass astrolabe, stacked grimoires and ley-line charts, rain on a dark window. |
+| 2 | `rain_street` | Background | `images/bg/rain_street.png` | 1920x1080 | 1 | Rain-slick city street after midnight, sodium streetlights smearing on wet asphalt, old townhouses, the chantry's silhouette at the far end. |
+| 3 | `chantry_exterior` | Background | `images/bg/chantry_exterior.png` | 1920x1080 | 1 | Imposing gothic townhouse (the Order's chantry), iron gate ajar, one amber-lit upper window, fog pooling on the stone steps. |
+| 4 | `sanctum_library` | Background | `images/bg/sanctum_library.png` | 1920x1080 | 2 | Two-storey sanctum library: floor-to-ceiling shelves, a great brass orrery, green-shaded lamps, a worktable strewn with star-charts. |
+| 5 | `sanctum_residue` | Background | `images/bg/sanctum_residue.png` | 1920x1080 | 2 | The same library through Awakened sight: glowing Prime residue, drifting motes, half-burnt sigils smouldering violet in the air. |
+| 6 | `node_chamber` | Background | `images/bg/node_chamber.png` | 1920x1080 | 3 | Stone undercroft housing the Node: a luminous quintessential spring at centre, a runic floor, warm gold light welling up the walls. |
+| 7 | `node_breach` | Background | `images/bg/node_breach.png` | 1920x1080 | 3 | The Node chamber gone wrong: a jagged tear of static and bruised light, the room's geometry bending, Paradox bleeding across the runes. |
+| 8 | `vigil_threshold` | Background | `images/bg/vigil_threshold.png` | 1920x1080 | 4 | A liminal dream-threshold: an endless candle-lit corridor dissolving into starless dark, reality worn thin -- where the wraith holds vigil. |
+| 9 | `dawn_rooftop` | Background | `images/bg/dawn_rooftop.png` | 1920x1080 | 5 | A city rooftop at first light: pale gold sky, mist over the streets, the storm spent. Quiet, exhausted dawn. |
+| 10 | `soraya neutral` | Sprite | `images/sprites/soraya/neutral.png` | 560x1040 | 1, 2, 3, 4, 5 | Soraya Mir, late 20s, Order of Hermes: dark coat over a waistcoat, ink-stained fingers, a brass focus-ring. Composed, watchful. |
+| 11 | `soraya focused` | Sprite | `images/sprites/soraya/focused.png` | 560x1040 | 2, 3, 4 | Soraya mid-working: eyes lit with Awakened focus, a hand tracing a sigil, a faint gold Quintessence glow at her fingertips. |
+| 12 | `soraya strained` | Sprite | `images/sprites/soraya/strained.png` | 560x1040 | 3, 4 | Soraya strained: jaw set, sweat at the brow, faint Paradox static crackling at her silhouette. Wounded resolve. |
+| 13 | `vance calm` | Sprite | `images/sprites/vance/calm.png` | 560x1040 | 1, 4 | Magister Aurelio Vance, 60s, silver-bearded, tweed jacket with a star-chart sash; kindly, tired eyes. The mentor as he was. |
+| 14 | `vance wraith` | Sprite | `images/sprites/vance/wraith.png` | 560x1040 | 4 | Vance consumed by Paradox: half-dissolved into flickering static and mirror-shards, eyes like blown-out screens. Sorrowful and monstrous. |
+| 15 | `corvin` | Sprite | `images/sprites/corvin/corvin.png` | 560x1040 | 2, 4 | Corvin, Vance's raven-familiar: a large black bird limned in faint silver spirit-light, too-knowing eyes. Visible only to Spirit sight. |
+| 16 | `cg_breach` | Event CG | `images/cg/breach.png` | 1920x1080 | 3 | The Node ruptures: Soraya silhouetted against a blossoming tear of Paradox light, charts and candle-flames whipping up around her. |
+| 17 | `cg_severance` | Event CG | `images/cg/severance.png` | 1920x1080 | 4 | Soraya severs the wraith's tether: a blade of Prime light parting Vance's static form, his face for one instant human again. |
+| 18 | `chronicle_title` | Title / UI | `images/ui/title.png` | 1200x460 | 1 | Title treatment: 'THE HOLLOW VIGIL' in engraved Cinzel-style serif with a faint hermetic sigil and ley-line motif. Transparent background. |
+
+> The canonical machine-readable version of this table is
+> [`game/images/manifest.yaml`](../game/images/manifest.yaml).

--- a/game/chronicle.rpy
+++ b/game/chronicle.rpy
@@ -192,6 +192,10 @@ label hv_scene3:
     else:
         soraya "So {i}this{/i} is what he hid down here. The vigil's failing, and the Node is tearing open."
 
+    # Resonance beat: a Static mage reads the breach's churn against her own grain.
+    if pc.gate("Static", ">=", 2):
+        "Your own Resonance is Static — order, permanence, the world keeping its shape. Against the breach's churn it is the one fixed point in the room, and you set your back to it."
+
     # Merit beat: Natural Channel lets her draw on the Node before acting.
     if pc.has("Natural Channel"):
         "As a Natural Channel, you feel the Node's Quintessence lean toward you, eager, even now."
@@ -437,15 +441,16 @@ label hv_scene5:
     $ hp_max = pc.resources.pools["health"].max
     $ cosmo = pc.get("Cosmology")
     $ arete = pc.get("Arete")
+    $ resonance = pc.identity.get("resonance", "—")
 
     "Final state of [final_name], [final_trad]:"
     "  Quintessence: [q_now]   Paradox: [p_now]"
     "  Willpower: [wp_now]/[wp_max]   Health: [hp_now]/[hp_max]"
-    "  Cosmology: [cosmo]   Arete: [arete]"
+    "  Cosmology: [cosmo]   Arete: [arete]   Resonance: [resonance]"
 
     "This chronicle exercised the WoD VN Framework:"
     "  - YAML character loading, set_active, and the persistent resource HUD"
-    "  - Stat-gated choices across Spheres, Abilities, Backgrounds, and resources"
+    "  - Stat-gated choices across Spheres, Abilities, Backgrounds, Resonance, and resources"
     "  - Hidden 'premium' gates (Correspondence and Forces) the protagonist can't reach"
     "  - Merit and Flaw checks (Natural Channel, Nightmares)"
     "  - Quintessence / Willpower / Health spending and the Quintessence–Paradox Wheel"

--- a/game/chronicle.rpy
+++ b/game/chronicle.rpy
@@ -163,9 +163,12 @@ label hv_travel:
 
     if not hv_studied:
         $ hv_studied = True
-        $ pc.advance("Cosmology")
-        $ wod_core.show_toast("Cosmology advanced to %d" % pc.get("Cosmology"))
-        "Piecing his logic together sharpens your own grasp of how Nodes and ley-lines truly knit. (Cosmology is now [pc.get('Cosmology')].)"
+        if pc.get("Cosmology") < pc.schema.get_range("Cosmology")[1]:
+            $ pc.advance("Cosmology")
+            $ wod_core.show_toast("Cosmology advanced to %d" % pc.get("Cosmology"))
+            "Piecing his logic together sharpens your own grasp of how Nodes and ley-lines truly knit. (Cosmology is now [pc.get('Cosmology')].)"
+        else:
+            "Piecing his logic together only confirms what you already grasp about how Nodes and ley-lines knit."
 
     "The pull from the stairwell is a cold hand on the back of your neck now. You go down."
 
@@ -250,8 +253,14 @@ label hv_stab_forces:
 label hv_stab_corr:
     # Hidden for Soraya; present for characters with Correspondence 2+.
     soraya "Don't fight it — move it. Send the overflow somewhere it can do no harm."
-    $ pc.spend("quintessence", 2)
-    "You fold the torn space against itself and route the surge out into the empty dark between places. The wound closes seamlessly."
+    $ ok = pc.spend("quintessence", 2)
+    if ok:
+        "You fold the torn space against itself and route the surge out into the empty dark between places. The wound closes seamlessly."
+    else:
+        $ pc.spend("willpower", 1)
+        $ pc.spend("health", 1)
+        $ hv_battered = True
+        "You haven't the Quintessence to move it cleanly, so you wrestle it shut by hand. It closes — and it costs."
     jump hv_after_breach
 
 
@@ -358,9 +367,15 @@ label hv_scene4:
 
         # Premium gate — hidden for the demo protagonist (Forces 3).
         "Overpower the wraith outright" if pc.gate("Forces", ">=", 4):
-            $ pc.spend("quintessence", 4)
-            "You hit the working like a hammer and it simply comes apart."
-            $ hv_mentor_fate = "released"
+            $ ok = pc.spend("quintessence", 4)
+            if ok:
+                "You hit the working like a hammer and it simply comes apart. He is released — there was no gentler way left to you."
+                $ hv_mentor_fate = "released"
+            else:
+                "You swing for it and close on empty — not the Quintessence to land the blow. The vigil fails on its own terms, and the Node tears wide before it dies."
+                $ pc.gain("paradox", 3)
+                $ hv_mentor_fate = "fled"
+                jump hv_scene5
 
         "You can't do this. Flee the threshold.":
             soraya "I'm sorry. I'm not strong enough for this."

--- a/game/chronicle.rpy
+++ b/game/chronicle.rpy
@@ -1,0 +1,440 @@
+## game/chronicle.rpy
+## ===========================================================================
+##  THE HOLLOW VIGIL  --  a Mage: The Ascension demo chronicle (5 scenes)
+## ===========================================================================
+##
+##  A complete, branching short story for the WoD VN Framework. It exercises:
+##    * Character loading from YAML + set_active + the resource HUD
+##    * Stat-gated menu choices (Spheres, Abilities, Backgrounds, resources),
+##      including "premium" gates that stay hidden for the demo protagonist
+##    * Merit / Flaw checks via pc.has() (Natural Channel, Nightmares)
+##    * Resource spend / gain: Quintessence, Willpower, Health
+##    * The linked Quintessence/Paradox Wheel (gaining Paradox pushes the Wheel)
+##    * Mid-story trait advancement (pc.advance)
+##    * Toast notifications and identity-field interpolation
+##    * Multi-ending outcome branching
+##
+##  ART: every `scene`/`show` below resolves through game/images.rpy. With no
+##  art installed, each renders a labelled PLACEHOLDER, so the chronicle is
+##  fully playable as-is. See game/images/manifest.yaml for the asset list.
+##
+##  Reached from the launcher in script.rpy:  label start -> chronicle_start.
+
+## ---- Speakers --------------------------------------------------------------
+define soraya = Character("Soraya", color="#c9a96e")
+define vance  = Character("Vance",  color="#b9c0c9")
+define wraith = Character("Vance",  color="#a85f86")   # the Paradox-touched form
+define corvin = Character("Corvin", color="#8fb9a9")
+
+## ---- Chronicle state (shared with save/load) -------------------------------
+default hv_knows_node   = False    # learned the Node is the key (Scene 1)
+default hv_saw_familiar = False    # perceived Corvin via Spirit (Scene 2)
+default hv_clue         = None     # what Scene 2 investigation revealed
+default hv_studied      = False    # one-time advancement guard (Scene 2)
+default hv_battered     = False    # took the breach the hard way (Scene 3)
+default hv_mentor_fate  = None     # released / anchored / reconciled / fled
+
+
+## ===========================================================================
+##  SCENE 1  --  THE SUMMONS
+## ===========================================================================
+label chronicle_start:
+
+    $ pc = wod_core.load_character("demo/soraya.yaml")
+    $ wod_core.set_active(pc)
+    $ wod_core.show_hud()
+    $ wod_core.show_toast("The Hollow Vigil")
+
+    $ pcname = pc.identity["name"]
+    $ pctrad = pc.identity.get("tradition", "a willworker")
+
+    scene apartment_night with fade
+    show chronicle_title at truecenter with dissolve
+    "{i}The Hollow Vigil{/i} — a Mage: The Ascension demo chronicle."
+    hide chronicle_title with dissolve
+
+    "Rain works the window like fingers. On your desk the ward-bell sits silent — and a silent ward-bell is the loudest thing in the world."
+
+    show soraya neutral at center with dissolve
+
+    soraya "Thirty years he's kept the new-moon vigil, and tonight the bell goes still."
+
+    "You are [pcname], of the [pctrad]. Magister Aurelio Vance took you as apprentice when no one else would. His wards have never once gone dark."
+
+    "They are dark now."
+
+    if pc.has("Nightmares"):
+        "Last night the dream came again: a candle that would not gutter, and your teacher's voice reciting coordinates you could not write down fast enough."
+        soraya "...I should have listened to the dream."
+
+    "There are a few ways to begin."
+
+    menu:
+        "Reach along the bond you share with your mentor" if pc.gate("Mentor", ">=", 3):
+            soraya "He taught me that a teacher leaves a thread in the student. Let me follow it."
+            "You quiet your mind and feel for him. The thread runs taut — downward, toward stone, toward the Node beneath his chantry."
+            $ hv_knows_node = True
+
+        "Comb his last letter for a cipher" if pc.gate("Investigation", ">=", 2):
+            "You spread his final letter under the lamp. Beneath the pleasantries, an acrostic: NODE FAILING. HELD IT MYSELF."
+            soraya "He was holding the Node open by hand. Oh, you stubborn old man."
+            $ hv_knows_node = True
+
+        # Premium gate — hidden for the demo protagonist (Correspondence 1).
+        "Scry his exact location across the city" if pc.gate("Correspondence", ">=", 3):
+            "Distance folds. You stand, for a heartbeat, in his sanctum's air."
+            $ hv_knows_node = True
+
+        "Stop guessing. Go to the chantry now.":
+            soraya "Enough. I'll find out when I get there."
+
+    "Either way, the answer is the same: his chantry, across the rain-dark city."
+
+    jump hv_travel
+
+
+## ===========================================================================
+##  SCENE 2  --  THE SANCTUM
+## ===========================================================================
+label hv_travel:
+
+    scene rain_street with fade
+    "The streets give you nothing but reflections. The chantry waits at the end of the row, hunched against the storm."
+
+    scene chantry_exterior with fade
+    "The iron gate stands ajar. One upper window burns amber. The steps are slick with fog that has no business being this thick."
+
+    soraya "The wards should have stopped me at the gate. They don't even notice me."
+
+    scene sanctum_library with fade
+    show soraya neutral at right with dissolve
+
+    "His sanctum library: two storeys of shelves, the great brass orrery — stopped — and a worktable drowned in star-charts. No Vance."
+
+    if pc.gate("Spirit", ">=", 2):
+        $ hv_saw_familiar = True
+        show corvin at left with dissolve
+        "A weight settles on the orrery. To your Spirit-sight a raven resolves out of the gloom, limned in cold silver."
+        corvin "Apprentice. He told me you'd come, or no one would."
+        corvin "He went {i}down{/i}. He's been holding the vigil three days. There's not enough of him left to hold it three more."
+        soraya "Corvin. Where — the Node?"
+        corvin "Where else. Look first. He left you reasons."
+    else:
+        "A raven watches you from the stopped orrery. You cannot quite hear what it is trying to say."
+
+    "Something below pulls at the edge of your attention. But Vance never did anything without leaving his reasons in the room."
+
+    menu:
+        "Read the residue of his last working" if pc.gate("Prime", ">=", 2):
+            soraya "Prime first. Let me see what he spent himself on."
+            $ ok = pc.spend("quintessence", 2)
+            if ok:
+                scene sanctum_residue with dissolve
+                show soraya focused at right with dissolve
+                if hv_saw_familiar:
+                    show corvin at left
+                "You burn two motes of Quintessence and the room blooms into Awakened sight: violet residue everywhere, all of it pouring {i}down{/i}."
+                $ gained = pc.gain("paradox", 1)
+                "A thread of someone else's Paradox clings to you on the way out — [gained] point of it."
+                $ hv_clue = "He poured his whole Pattern into the Node to keep it open."
+                soraya "He's been feeding it himself. Pattern and all."
+            else:
+                "Your reserves are too thin to spare even that. The residue stays just out of focus."
+                $ hv_clue = "His working led downward, toward the Node."
+
+        "Decipher the sigils burned into the desk" if pc.gate("Occult", ">=", 3):
+            "The scorched sigils name the working in old Hermetic shorthand: {i}Vigil of the Hollow Hour{/i} — to hold a dying Node open by will alone."
+            $ hv_clue = "The working is the Hollow Vigil: holding a dying Node open by will alone."
+            soraya "A working with no end condition. It only stops when {i}you{/i} do."
+
+        "Search the worktable and shelves" if pc.gate("Investigation", ">=", 3):
+            "His journal lies open to the last entry: {i}The Technocrats found the Node. They mean to bleed it dry. I will not let them. If I must be the wall, I will be the wall.{/i}"
+            $ hv_clue = "The Technocracy was draining the Node; Vance made himself its wall."
+            soraya "You didn't call for help. You never call for help."
+
+        "Open your senses to the whole room" if pc.gate("Awareness", ">=", 3):
+            "You let your Awareness widen. The library is a held breath. Far below, something is straining — a chord pulled a half-step sharp and never released."
+            $ hv_clue = "Something far below is straining, about to give."
+            soraya "Whatever he's doing, it's about to break."
+
+        "Skip the reading — go straight down.":
+            soraya "No time for forensics. Down."
+            $ hv_clue = None
+
+    if not hv_studied:
+        $ hv_studied = True
+        $ pc.advance("Cosmology")
+        $ wod_core.show_toast("Cosmology advanced to %d" % pc.get("Cosmology"))
+        "Piecing his logic together sharpens your own grasp of how Nodes and ley-lines truly knit. (Cosmology is now [pc.get('Cosmology')].)"
+
+    "The pull from the stairwell is a cold hand on the back of your neck now. You go down."
+
+    jump hv_scene3
+
+
+## ===========================================================================
+##  SCENE 3  --  THE BREACH
+## ===========================================================================
+label hv_scene3:
+
+    scene node_chamber with fade
+    show soraya neutral at center with dissolve
+
+    "The undercroft should glow. The Node — a spring of pure Quintessence in the living rock — should fill this chamber with steady gold."
+
+    "Instead it gutters like a candle in a draught, and the draught is coming from a {i}wound{/i} in the air above it."
+
+    if hv_knows_node:
+        soraya "Just as the thread warned me. The vigil's failing — and the Node is tearing open."
+    else:
+        soraya "So {i}this{/i} is what he hid down here. The vigil's failing, and the Node is tearing open."
+
+    # Merit beat: Natural Channel lets her draw on the Node before acting.
+    if pc.has("Natural Channel"):
+        "As a Natural Channel, you feel the Node's Quintessence lean toward you, eager, even now."
+        menu:
+            "Draw on the Node to steady your reserves" if pc.gate("quintessence", "<", 18):
+                $ got = pc.gain("quintessence", 3)
+                $ wod_core.show_toast("Channelled +%d Quintessence" % got)
+                "Gold floods your Pattern. You hold [pc.resources.current('quintessence')] now."
+                soraya "Forgive me. I'll give it back if there's anything left to give it to."
+
+            "Leave the dying Node its strength":
+                soraya "No. It's bleeding out. I won't be one more thing draining it."
+
+    "The tear yawns wider. Charts lift off the floor. You have one move before it floods the chantry above."
+
+    scene cg_breach with dissolve
+    "Light the colour of a bruise blossoms out of the wound. It is now or not at all."
+    scene node_breach with dissolve
+    show soraya focused at center with dissolve
+
+    menu:
+        "Damp the surge with raw Forces" if pc.gate("Forces", ">=", 3):
+            jump hv_stab_forces
+
+        # Premium gate — hidden for the demo protagonist (Correspondence 1).
+        "Reroute the flow through Correspondence" if pc.gate("Correspondence", ">=", 2):
+            jump hv_stab_corr
+
+        "Seal the spirit-breach with a ward" if pc.gate("Spirit", ">=", 2):
+            jump hv_stab_spirit
+
+        "No finesse left — raise a shield and ride it out":
+            jump hv_stab_shield
+
+
+label hv_stab_forces:
+    soraya "Forces, then. Pull the heat out of it before it blows."
+    $ ok = pc.spend("quintessence", 3)
+    if ok:
+        "You reach into the surge and {i}wrench{/i}. The wound's roar drops to a sullen hiss."
+        $ gained = pc.gain("paradox", 2)
+        "But reality keeps its ledger. [gained] points of Paradox crackle into your Pattern."
+        if pc.gate("paradox", ">=", 4):
+            show soraya strained at center with dissolve
+            $ pc.spend("health", 1)
+            $ wod_core.show_toast("Paradox backlash!")
+            $ hv_battered = True
+            "The static lashes back across your skin. It {i}hurts.{/i}"
+        soraya "Held. Barely."
+    else:
+        "Your reserves gutter out mid-cast — not enough Quintessence to bend it."
+        $ pc.spend("willpower", 1)
+        $ pc.spend("health", 1)
+        $ hv_battered = True
+        "You take the surge on your own Pattern instead. It leaves a mark."
+    jump hv_after_breach
+
+
+label hv_stab_corr:
+    # Hidden for Soraya; present for characters with Correspondence 2+.
+    soraya "Don't fight it — move it. Send the overflow somewhere it can do no harm."
+    $ pc.spend("quintessence", 2)
+    "You fold the torn space against itself and route the surge out into the empty dark between places. The wound closes seamlessly."
+    jump hv_after_breach
+
+
+label hv_stab_spirit:
+    soraya "A spirit-breach needs a spirit-ward. Hold still."
+    $ ok = pc.spend("quintessence", 2)
+    if ok:
+        $ pc.spend("willpower", 1)
+        "You weave a lattice of Spirit across the tear. Edge by edge it knits shut, sealed in cold silver."
+        if hv_saw_familiar:
+            corvin "Clean work. He'd have said so himself."
+        soraya "It'll hold. For now."
+    else:
+        $ pc.spend("willpower", 1)
+        $ pc.spend("health", 1)
+        $ hv_battered = True
+        "You haven't the Quintessence to anchor the ward, so you anchor it with yourself. It holds — and it costs."
+    jump hv_after_breach
+
+
+label hv_stab_shield:
+    show soraya strained at center with dissolve
+    soraya "No finesse left. Just endure."
+    $ pc.spend("willpower", 1)
+    $ pc.spend("health", 1)
+    $ hv_battered = True
+    "You wrap yourself in a flat wall of will and let the wound scream itself hoarse. When it finally sags shut, so do you, almost."
+    jump hv_after_breach
+
+
+label hv_after_breach:
+    "The breach quiets to a seam. But the chamber is not empty now."
+    if hv_clue:
+        "What you pieced together upstairs settles into place: [hv_clue]"
+    "Something stands over the guttering Node — a figure of candle-shadow and static, still holding a working that should have ended days ago."
+    soraya "...Vance."
+    jump hv_scene4
+
+
+## ===========================================================================
+##  SCENE 4  --  THE VIGIL  (climax)
+## ===========================================================================
+label hv_scene4:
+
+    scene vigil_threshold with fade
+    show vance wraith at center with dissolve
+
+    "The chamber thins into a threshold — an endless candle-lit corridor folding into starless dark. Here the vigil is being kept, and the one keeping it has paid for every hour in Pattern."
+
+    wraith "Not... finished. The wall holds. I hold. Go back, apprentice, the wall holds —"
+
+    "Paradox has him by the seams. Half Vance, half blown-out screen. He has held the Node open so long he has forgotten he is allowed to stop."
+
+    if hv_saw_familiar:
+        show corvin at left with dissolve
+        corvin "He can't hear reason as reason anymore. You'll have to mean it with everything you've got."
+
+    soraya "Magister. The Technocrats are gone. The vigil's over. You can let go."
+    wraith "Can't. If I let go the Node dies. If the Node dies they win. Can't, can't —"
+
+    "You will have to steady yourself before you do anything in this place."
+
+    menu:
+        "Sever the vigil — release him and the Node together" if pc.gate("Spirit", ">=", 2) and pc.gate("Prime", ">=", 2):
+            $ ok = pc.spend("quintessence", 3)
+            if ok:
+                $ pc.spend("willpower", 1)
+                scene cg_severance with dissolve
+                "You shape a blade of Prime and Spirit and bring it down on the tether binding him to the Node. For one instant his face is wholly his own."
+                vance "...Ah. {i}There{/i} you are. Good girl. Let it go, both of us — let it —"
+                "The tether parts. The Node sighs out its last gold light and goes quiet, whole. Vance goes with it, freed."
+                $ hv_mentor_fate = "released"
+            else:
+                "You haven't the Quintessence to shape the blade. The working stutters and dies in your hands."
+                soraya "No — not enough —"
+                $ hv_mentor_fate = "fled"
+                jump hv_scene5
+
+        "Anchor him — pour your own Pattern into his" if pc.gate("Prime", ">=", 2):
+            $ ok = pc.spend("quintessence", 4)
+            if ok:
+                $ pc.spend("willpower", 2)
+                show soraya strained at center with dissolve
+                "You drive your own Pattern into the gaps in his, a splint of living Prime. It is reckless and it half-works."
+                $ pc.gain("paradox", 2)
+                "The wraith-static recedes. What's left of Vance sags into something that can, at least, be carried out."
+                vance "...shouldn't have. Foolish... thank you."
+                $ hv_mentor_fate = "anchored"
+            else:
+                "You reach for the Quintessence to anchor him and close on nothing. There isn't enough of you to splint him with."
+                $ pc.spend("willpower", 1)
+                $ hv_mentor_fate = "fled"
+                jump hv_scene5
+
+        "Reach him through the bond he left in you" if pc.gate("Mentor", ">=", 3):
+            $ pc.spend("willpower", 2)
+            "You stop casting. You follow the teacher's-thread instead, the one he tied in you years ago, and you {i}pull{/i} — not the Node, him."
+            soraya "You taught me a vigil is a promise to {i}watch{/i}, not to become the wall. Keep your own teaching. I'll watch now. Rest."
+            "Something in the static stills. Listens. Remembers it has a name."
+            show vance calm at center with dissolve
+            vance "...Soraya. Yes. Yes — I can put it down. {i}You'll{/i} watch."
+            "He lets go by his own hand, and the Node closes gently around the choice."
+            $ hv_mentor_fate = "reconciled"
+
+        # Premium gate — hidden for the demo protagonist (Forces 3).
+        "Overpower the wraith outright" if pc.gate("Forces", ">=", 4):
+            $ pc.spend("quintessence", 4)
+            "You hit the working like a hammer and it simply comes apart."
+            $ hv_mentor_fate = "released"
+
+        "You can't do this. Flee the threshold.":
+            soraya "I'm sorry. I'm not strong enough for this."
+            "You turn and run. Behind you the vigil finally fails on its own terms, and the Node tears wide before it dies."
+            $ pc.gain("paradox", 3)
+            $ hv_mentor_fate = "fled"
+
+    jump hv_scene5
+
+
+## ===========================================================================
+##  SCENE 5  --  AFTERMATH
+## ===========================================================================
+label hv_scene5:
+
+    scene dawn_rooftop with fade
+    if hv_battered:
+        show soraya strained at center with dissolve
+    else:
+        show soraya neutral at center with dissolve
+
+    "Dawn finds the rooftop the colour of weak tea. The storm has wrung itself out. Below, the city has no idea how close it came."
+
+    if hv_mentor_fate == "reconciled":
+        "He is gone, but he went as himself — by his own choice, at the end of a promise kept. That is as much as any mage gets."
+        soraya "You watched over me. I watched you out. We're square, old man."
+    elif hv_mentor_fate == "released":
+        "You freed him with a blade of his own teaching. Clean, and final, and kinder than the alternative."
+        soraya "Rest. The vigil's mine now, and I'll keep it the way you should have — by knowing when to stop."
+    elif hv_mentor_fate == "anchored":
+        "He breathes. Diminished, hollowed, but breathing — and the Paradox you took on to do it sits in your chest like a swallowed coal."
+        soraya "You'll hate being saved. I'll live with that. We both will."
+    else:  # fled
+        "You ran, and the Node died screaming, and Vance with it. The chantry stands empty above a dark spring. You will carry that."
+        soraya "...I'll be ready next time. I have to be."
+
+    if hv_saw_familiar:
+        show corvin at left with dissolve
+        if hv_mentor_fate == "fled":
+            corvin "He chose his vigil. You'll choose a better one. I'll be watching to make sure."
+        else:
+            corvin "A familiar outlives its mage. I'll keep your hours now, apprentice — Magister."
+        soraya "...I'd like that, Corvin."
+
+    "You take stock of what the night cost you."
+
+    scene black with fade
+
+    "{i}— The Hollow Vigil —{/i}"
+
+    # Precompute final-state values to keep interpolation simple and safe.
+    $ final_name = pc.identity["name"]
+    $ final_trad = pc.identity.get("tradition", "")
+    $ q_now = pc.resources.current("quintessence")
+    $ p_now = pc.resources.current("paradox")
+    $ wp_now = pc.resources.current("willpower")
+    $ wp_max = pc.resources.pools["willpower"].max
+    $ hp_now = pc.resources.current("health")
+    $ hp_max = pc.resources.pools["health"].max
+    $ cosmo = pc.get("Cosmology")
+    $ arete = pc.get("Arete")
+
+    "Final state of [final_name], [final_trad]:"
+    "  Quintessence: [q_now]   Paradox: [p_now]"
+    "  Willpower: [wp_now]/[wp_max]   Health: [hp_now]/[hp_max]"
+    "  Cosmology: [cosmo]   Arete: [arete]"
+
+    "This chronicle exercised the WoD VN Framework:"
+    "  - YAML character loading, set_active, and the persistent resource HUD"
+    "  - Stat-gated choices across Spheres, Abilities, Backgrounds, and resources"
+    "  - Hidden 'premium' gates (Correspondence and Forces) the protagonist can't reach"
+    "  - Merit and Flaw checks (Natural Channel, Nightmares)"
+    "  - Quintessence / Willpower / Health spending and the Quintessence–Paradox Wheel"
+    "  - Mid-story advancement (Cosmology) and multi-ending branching"
+
+    $ wod_core.hide_hud()
+    return

--- a/game/demo/soraya.yaml
+++ b/game/demo/soraya.yaml
@@ -15,6 +15,7 @@ identity:
   name: "Soraya Mir"
   tradition: "Order of Hermes"
   essence: "Pattern"
+  resonance: "Static"
   nature: "Visionary"
   demeanor: "Architect"
   concept: "Ley-line cartographer and reluctant heir to a vanished mentor"
@@ -55,6 +56,8 @@ traits:
     Node: 2
     Sanctum: 1
     Wonder: 1
+  resonance:
+    Static: 2
 
 resources:
   quintessence: 8

--- a/game/demo/soraya.yaml
+++ b/game/demo/soraya.yaml
@@ -1,0 +1,66 @@
+# Demo chronicle protagonist: Soraya Mir, Order of Hermes
+#
+# Stats are tuned so every "main path" branch of THE HOLLOW VIGIL is reachable,
+# while a few "premium" gates stay just out of reach to demonstrate how gating
+# hides choices (e.g. Correspondence >= 3, Forces >= 4).
+#
+# Reachable gates:  Forces 3 / Prime 2 / Spirit 2 / Awareness 3 / Occult 3 /
+#                   Investigation 3 / Expression 2 / Mentor 3 / Avatar 3 / Node 2
+# Hidden gates:     Correspondence >= 3 (has 1) / Forces >= 4 (has 3) / Contacts (has 0)
+schema: mage
+template: default_mage
+character_type: pc
+
+identity:
+  name: "Soraya Mir"
+  tradition: "Order of Hermes"
+  essence: "Pattern"
+  nature: "Visionary"
+  demeanor: "Architect"
+  concept: "Ley-line cartographer and reluctant heir to a vanished mentor"
+
+traits:
+  attributes:
+    Strength: 2
+    Dexterity: 2
+    Stamina: 3
+    Charisma: 3
+    Manipulation: 3
+    Appearance: 2
+    Perception: 4
+    Intelligence: 4
+    Wits: 3
+  abilities:
+    Alertness: 2
+    Awareness: 3
+    Expression: 2
+    Meditation: 2
+    Research: 2
+    Academics: 2
+    Cosmology: 2
+    Esoterica: 2
+    Investigation: 3
+    Occult: 3
+    Technology: 1
+  spheres:
+    Forces: 3
+    Prime: 2
+    Spirit: 2
+    Correspondence: 1
+  arete:
+    Arete: 3
+  backgrounds:
+    Avatar: 3
+    Mentor: 3
+    Node: 2
+    Sanctum: 1
+    Wonder: 1
+
+resources:
+  quintessence: 8
+  paradox: 0
+  willpower: 6
+
+merits_flaws:
+  - { name: "Natural Channel", type: merit, value: 3 }
+  - { name: "Nightmares", type: flaw, value: -1 }

--- a/game/images.rpy
+++ b/game/images.rpy
@@ -1,0 +1,150 @@
+## game/images.rpy
+## Demo chronicle art registry  --  "The Hollow Vigil"
+##
+## Every image the chronicle uses is registered here ONCE, in WOD_CHRONICLE_ART.
+## For each entry:
+##   * If the real art file exists (its `target` path is loadable), that file is
+##     used as the image.
+##   * Otherwise a labelled on-screen PLACEHOLDER is generated automatically, so
+##     the chronicle runs end-to-end with zero art assets.
+##
+## To ship real art: drop a file at the listed `target` path (e.g.
+## game/images/bg/sanctum_library.png) and it overrides the placeholder on the
+## next launch -- NO code change required. The script references images by the
+## short `name` (e.g. `scene sanctum_library`), which is decoupled from the file
+## path, so you can organise the images/ folder however you like.
+##
+## The canonical, human- and machine-readable list of what art is needed lives
+## in game/images/manifest.yaml  (see also docs/demo-chronicle.md).
+
+init python:
+
+    import textwrap
+
+    # Per-kind (base fill, accent) colours for the placeholder cards.
+    _WOD_PH_PALETTE = {
+        "bg":     ("#0e1118", "#c9a96e"),   # backgrounds  -- warm gold accent
+        "cg":     ("#160e16", "#d98fb0"),   # event CGs     -- rose accent
+        "sprite": ("#0b0f0d", "#7fc9ad"),   # characters    -- jade accent
+        "ui":     ("#13130d", "#c9c07e"),   # title / UI    -- pale gold accent
+    }
+
+    def _wod_placeholder(kind, name, desc, w, h, target):
+        """Build a self-describing placeholder displayable (no art needed).
+
+        Uses only Fixed/Solid/Text so it is valid on any Ren'Py 8.x install.
+        """
+        base, accent = _WOD_PH_PALETTE.get(kind, ("#101010", "#dddddd"))
+
+        wide = w >= 900
+        big   = 54 if wide else 32     # asset name
+        body  = 26 if wide else 18     # art-direction note
+        small = 20 if wide else 14     # dimensions / path
+        wrap  = max(18, min(58, w // 22))
+
+        # (text, size, colour) rows, top to bottom. Empty text == vertical gap.
+        rows = [(kind.upper() + " PLACEHOLDER", small, "#7d7d7d"), ("", body // 2, base)]
+        rows.append((name, big, accent))
+        rows.append(("", body // 2, base))
+        for line in textwrap.wrap(desc, width=wrap):
+            rows.append((line, body, "#d2d2d2"))
+        rows.append(("", body // 2, base))
+        rows.append(("%d x %d" % (w, h), small, "#6b6b6b"))
+        rows.append((target, small, "#6b6b6b"))
+
+        total = sum(sz + 8 for _, sz, _ in rows)
+        y = max(8, (h - total) // 2)
+
+        children = [
+            Solid(accent, xysize=(w, h)),                              # border
+            Solid(base, xysize=(w - 6, h - 6), xpos=3, ypos=3),        # inner fill
+        ]
+        for text, sz, col in rows:
+            if text:
+                children.append(Text(
+                    text, size=sz, color=col,
+                    xpos=w // 2, xanchor=0.5, ypos=y, yanchor=0.0,
+                    outlines=[(2, "#000000", 0, 0)],
+                ))
+            y += sz + 8
+
+        return Fixed(*children, xysize=(w, h))
+
+    def _wod_register_art(name, kind, target, w, h, desc):
+        """Define `name` as the real file if present, else a placeholder."""
+        if renpy.loadable(target):
+            renpy.image(name, target)
+        else:
+            renpy.image(name, _wod_placeholder(kind, name, desc, w, h, target))
+
+    # ------------------------------------------------------------------ #
+    #  ART REGISTRY  --  keep in sync with game/images/manifest.yaml      #
+    #  (image name, kind, target file, width, height, art direction)      #
+    # ------------------------------------------------------------------ #
+    WOD_CHRONICLE_ART = [
+
+        # ---- Backgrounds (1920x1080) -------------------------------------
+        ("apartment_night", "bg", "images/bg/apartment_night.png", 1920, 1080,
+         "Soraya's cramped Hermetic study at night: candle-lit desk, brass astrolabe, "
+         "stacked grimoires and ley-line charts, rain streaking a dark window."),
+        ("rain_street", "bg", "images/bg/rain_street.png", 1920, 1080,
+         "Rain-slick city street after midnight, sodium streetlights smearing on wet "
+         "asphalt, a row of old townhouses, the chantry's silhouette at the end."),
+        ("chantry_exterior", "bg", "images/bg/chantry_exterior.png", 1920, 1080,
+         "Imposing gothic townhouse -- the Order's chantry -- iron gate ajar, a single "
+         "amber-lit upper window, fog pooling on the stone steps."),
+        ("sanctum_library", "bg", "images/bg/sanctum_library.png", 1920, 1080,
+         "Two-storey sanctum library: floor-to-ceiling shelves, a great brass orrery, "
+         "green-shaded lamps, a heavy worktable strewn with star-charts."),
+        ("sanctum_residue", "bg", "images/bg/sanctum_residue.png", 1920, 1080,
+         "The same library through Awakened sight: glowing Prime residue, drifting "
+         "motes, half-burnt sigils smouldering violet in the air."),
+        ("node_chamber", "bg", "images/bg/node_chamber.png", 1920, 1080,
+         "Stone undercroft housing the Node: a luminous quintessential spring at centre, "
+         "a runic floor, warm gold light welling up the walls."),
+        ("node_breach", "bg", "images/bg/node_breach.png", 1920, 1080,
+         "The Node chamber gone wrong: a jagged tear of static and bruised light, the "
+         "geometry of the room bending, Paradox bleeding across the runes."),
+        ("vigil_threshold", "bg", "images/bg/vigil_threshold.png", 1920, 1080,
+         "A liminal dream-threshold: an endless candle-lit corridor dissolving into "
+         "starless dark, reality worn thin -- where the wraith holds vigil."),
+        ("dawn_rooftop", "bg", "images/bg/dawn_rooftop.png", 1920, 1080,
+         "A city rooftop at first light: pale gold sky, mist over the streets below, "
+         "the storm spent. Quiet, exhausted dawn."),
+
+        # ---- Character sprites (560x1040, transparent) -------------------
+        ("soraya neutral", "sprite", "images/sprites/soraya/neutral.png", 560, 1040,
+         "Soraya Mir, late 20s, Order of Hermes: dark coat over a waistcoat, ink-stained "
+         "fingers, a brass focus-ring. Composed, watchful. Neutral expression."),
+        ("soraya focused", "sprite", "images/sprites/soraya/focused.png", 560, 1040,
+         "Soraya mid-working: eyes lit with Awakened focus, one hand tracing a sigil, a "
+         "faint gold Quintessence glow at her fingertips. Casting expression."),
+        ("soraya strained", "sprite", "images/sprites/soraya/strained.png", 560, 1040,
+         "Soraya strained: jaw set, sweat at the brow, faint Paradox static crackling at "
+         "her silhouette. Wounded resolve."),
+        ("vance calm", "sprite", "images/sprites/vance/calm.png", 560, 1040,
+         "Magister Aurelio Vance, 60s, silver-bearded, tweed jacket with a star-chart "
+         "sash; kindly, tired eyes. The mentor as he was -- for flashbacks."),
+        ("vance wraith", "sprite", "images/sprites/vance/wraith.png", 560, 1040,
+         "Vance consumed by Paradox: half-dissolved into flickering static and "
+         "mirror-shards, eyes like blown-out screens. Sorrowful and monstrous."),
+        ("corvin", "sprite", "images/sprites/corvin/corvin.png", 560, 1040,
+         "Corvin, Vance's raven-familiar: a large black bird limned in faint silver "
+         "spirit-light, too-knowing eyes, head cocked. Visible only to Spirit sight."),
+
+        # ---- Event CGs (1920x1080) ---------------------------------------
+        ("cg_breach", "cg", "images/cg/breach.png", 1920, 1080,
+         "Splash CG: the Node ruptures. Soraya silhouetted against a blossoming tear of "
+         "Paradox light, charts and candle-flames whipping up around her."),
+        ("cg_severance", "cg", "images/cg/severance.png", 1920, 1080,
+         "Splash CG: Soraya severs the wraith's tether -- a blade of Prime light parting "
+         "Vance's static form, his face for one instant human again."),
+
+        # ---- Title / UI --------------------------------------------------
+        ("chronicle_title", "ui", "images/ui/title.png", 1200, 460,
+         "Title treatment: 'THE HOLLOW VIGIL' in engraved Cinzel-style serif, a faint "
+         "hermetic sigil and ley-line motif behind it. Transparent background."),
+    ]
+
+    for _entry in WOD_CHRONICLE_ART:
+        _wod_register_art(*_entry)

--- a/game/images/manifest.yaml
+++ b/game/images/manifest.yaml
@@ -1,0 +1,161 @@
+# ============================================================================
+#  IMAGE MANIFEST  --  Demo chronicle "The Hollow Vigil" (Mage: The Ascension)
+# ============================================================================
+#
+# This is the canonical list of art assets the demo chronicle needs. Until a
+# real file is supplied, the framework renders a self-describing placeholder
+# (see game/images.rpy), so the chronicle is fully playable with NO art.
+#
+# To supply real art, drop a file at the `file` path below. The runtime checks
+# `renpy.loadable(file)` and uses the file if present -- no code change needed.
+#
+# Conventions:
+#   * `name`  -- the image name the script references (decoupled from `file`).
+#   * `file`  -- where to put the real asset, relative to game/.
+#   * `size`  -- target [width, height] in px. Backgrounds/CGs are full-frame
+#                at the project resolution (1920x1080, see game/gui.rpy).
+#   * Sprites should be PNGs with transparency, full-figure, bottom-aligned.
+#
+# Keep this file in sync with WOD_CHRONICLE_ART in game/images.rpy.
+
+meta:
+  chronicle: "The Hollow Vigil"
+  splat: mage
+  resolution: [1920, 1080]
+  protagonist: "Soraya Mir, Order of Hermes (game/demo/soraya.yaml)"
+  placeholder_source: game/images.rpy
+  total_assets: 18
+
+backgrounds:
+  - name: apartment_night
+    file: images/bg/apartment_night.png
+    size: [1920, 1080]
+    scenes: [1]
+    description: >-
+      Soraya's cramped Hermetic study at night: candle-lit desk, brass
+      astrolabe, stacked grimoires and ley-line charts, rain on a dark window.
+  - name: rain_street
+    file: images/bg/rain_street.png
+    size: [1920, 1080]
+    scenes: [1]
+    description: >-
+      Rain-slick city street after midnight, sodium streetlights smearing on
+      wet asphalt, old townhouses, the chantry's silhouette at the far end.
+  - name: chantry_exterior
+    file: images/bg/chantry_exterior.png
+    size: [1920, 1080]
+    scenes: [1]
+    description: >-
+      Imposing gothic townhouse (the Order's chantry), iron gate ajar, one
+      amber-lit upper window, fog pooling on the stone steps.
+  - name: sanctum_library
+    file: images/bg/sanctum_library.png
+    size: [1920, 1080]
+    scenes: [2]
+    description: >-
+      Two-storey sanctum library: floor-to-ceiling shelves, a great brass
+      orrery, green-shaded lamps, a worktable strewn with star-charts.
+  - name: sanctum_residue
+    file: images/bg/sanctum_residue.png
+    size: [1920, 1080]
+    scenes: [2]
+    description: >-
+      The same library through Awakened sight: glowing Prime residue, drifting
+      motes, half-burnt sigils smouldering violet in the air.
+  - name: node_chamber
+    file: images/bg/node_chamber.png
+    size: [1920, 1080]
+    scenes: [3]
+    description: >-
+      Stone undercroft housing the Node: a luminous quintessential spring at
+      centre, a runic floor, warm gold light welling up the walls.
+  - name: node_breach
+    file: images/bg/node_breach.png
+    size: [1920, 1080]
+    scenes: [3]
+    description: >-
+      The Node chamber gone wrong: a jagged tear of static and bruised light,
+      the room's geometry bending, Paradox bleeding across the runes.
+  - name: vigil_threshold
+    file: images/bg/vigil_threshold.png
+    size: [1920, 1080]
+    scenes: [4]
+    description: >-
+      A liminal dream-threshold: an endless candle-lit corridor dissolving into
+      starless dark, reality worn thin -- where the wraith holds vigil.
+  - name: dawn_rooftop
+    file: images/bg/dawn_rooftop.png
+    size: [1920, 1080]
+    scenes: [5]
+    description: >-
+      A city rooftop at first light: pale gold sky, mist over the streets, the
+      storm spent. Quiet, exhausted dawn.
+
+sprites:
+  - name: soraya neutral
+    file: images/sprites/soraya/neutral.png
+    size: [560, 1040]
+    scenes: [1, 2, 3, 4, 5]
+    description: >-
+      Soraya Mir, late 20s, Order of Hermes: dark coat over a waistcoat,
+      ink-stained fingers, a brass focus-ring. Composed, watchful.
+  - name: soraya focused
+    file: images/sprites/soraya/focused.png
+    size: [560, 1040]
+    scenes: [2, 3, 4]
+    description: >-
+      Soraya mid-working: eyes lit with Awakened focus, a hand tracing a sigil,
+      a faint gold Quintessence glow at her fingertips.
+  - name: soraya strained
+    file: images/sprites/soraya/strained.png
+    size: [560, 1040]
+    scenes: [3, 4]
+    description: >-
+      Soraya strained: jaw set, sweat at the brow, faint Paradox static
+      crackling at her silhouette. Wounded resolve.
+  - name: vance calm
+    file: images/sprites/vance/calm.png
+    size: [560, 1040]
+    scenes: [1, 4]
+    description: >-
+      Magister Aurelio Vance, 60s, silver-bearded, tweed jacket with a
+      star-chart sash; kindly, tired eyes. The mentor as he was.
+  - name: vance wraith
+    file: images/sprites/vance/wraith.png
+    size: [560, 1040]
+    scenes: [4]
+    description: >-
+      Vance consumed by Paradox: half-dissolved into flickering static and
+      mirror-shards, eyes like blown-out screens. Sorrowful and monstrous.
+  - name: corvin
+    file: images/sprites/corvin/corvin.png
+    size: [560, 1040]
+    scenes: [2, 4]
+    description: >-
+      Corvin, Vance's raven-familiar: a large black bird limned in faint silver
+      spirit-light, too-knowing eyes. Visible only to Spirit sight.
+
+cgs:
+  - name: cg_breach
+    file: images/cg/breach.png
+    size: [1920, 1080]
+    scenes: [3]
+    description: >-
+      The Node ruptures: Soraya silhouetted against a blossoming tear of Paradox
+      light, charts and candle-flames whipping up around her.
+  - name: cg_severance
+    file: images/cg/severance.png
+    size: [1920, 1080]
+    scenes: [4]
+    description: >-
+      Soraya severs the wraith's tether: a blade of Prime light parting Vance's
+      static form, his face for one instant human again.
+
+ui:
+  - name: chronicle_title
+    file: images/ui/title.png
+    size: [1200, 460]
+    scenes: [1]
+    description: >-
+      Title treatment: 'THE HOLLOW VIGIL' in engraved Cinzel-style serif with a
+      faint hermetic sigil and ley-line motif. Transparent background.

--- a/game/script.rpy
+++ b/game/script.rpy
@@ -10,6 +10,22 @@ default pc = None
 
 label start:
 
+    ## WoD VN Framework — demo launcher.
+    ## Pick the multi-scene chronicle or the short feature demo.
+    scene black with fade
+
+    menu:
+        "{b}WoD VN Framework{/b} — choose a demo:"
+
+        "The Hollow Vigil — a Mage demo chronicle (5 scenes)":
+            jump chronicle_start
+
+        "Quick feature demo — Elena vs. the Technocratic Ward":
+            jump feature_demo
+
+
+label feature_demo:
+
     ## Load the demo character
     $ pc = wod_core.load_character("demo/elena.yaml")
     $ wod_core.set_active(pc)


### PR DESCRIPTION
## Summary

Adds **The Hollow Vigil**, a complete branching **Mage: The Ascension** demo chronicle (5 scenes, multiple endings) built on the framework, plus a placeholder-art system and an art manifest. It plays **start-to-finish with zero art assets** — every image renders a labelled on-screen placeholder until a real file is supplied.

A title-screen launcher lets the player pick the chronicle or the existing single-scene *Elena vs. the Technocratic Ward* feature demo (preserved unchanged).

## What's included

| File | Purpose |
|------|---------|
| `game/chronicle.rpy` | The 5-scene chronicle: **The Summons → The Sanctum → The Breach → The Vigil → Aftermath**, with four endings. |
| `game/demo/soraya.yaml` | Protagonist **Soraya Mir** (Order of Hermes), stat-tuned so main-path gates are reachable and two premium gates stay hidden. |
| `game/images.rpy` | Art registry: uses the real file if present (`renpy.loadable`), else draws a self-describing placeholder. |
| `game/images/manifest.yaml` | Canonical manifest of all **18** needed images (name, path, size, scenes, art direction). |
| `docs/demo-chronicle.md` | Walkthrough, per-scene feature map, art swap-in guide, and the manifest table. |
| `game/script.rpy` | Title-screen launcher (chronicle + feature demo). |

## Scenes & framework coverage

The chronicle deliberately exercises every core feature:

- **Stat gating** across Spheres, Abilities, Backgrounds, **and** resources — including two **hidden premium gates** (`Correspondence >= 3`, `Forces >= 4`) Soraya can't reach, to show gating *hides* rather than fails choices.
- **Merit/Flaw checks** (`Natural Channel`, `Nightmares`).
- **Resource spend/gain**: Quintessence, Willpower, Health, plus the linked **Quintessence–Paradox Wheel** and a Paradox-backlash branch.
- **Mid-story advancement** (`Cosmology`) with a toast.
- **Four-way ending branch** keyed on player choices and resource state.

Every menu has an unconditional fallback, so the chronicle is always completable.

## Placeholders & swapping in art

Images are referenced by short logical names (e.g. `sanctum_library`, `soraya focused`) decoupled from file paths. To ship real art, just drop a file at the path in the manifest — **no code change needed**. With no art installed, each placeholder shows its type, name, target size, path, and art-direction note on screen.

## Running

```bash
renpy.sh game/
```
Then choose **"The Hollow Vigil — a Mage demo chronicle (5 scenes)."**

## Validation

- Existing test suite green (**122 passed**).
- `demo/soraya.yaml` loads; all intended gates resolve (reachable vs. hidden) as designed.
- Static checks: every `scene`/`show`/`hide` image, every `jump`/`call` label, and every `gate`/`has`/`get`/`advance`/`spend`/`gain` identifier resolves against the schema.
- `manifest.yaml` and the `images.rpy` registry agree (18 assets).
- `images.rpy` `init python` block compiles as valid Python and the placeholder builder runs cleanly for all 18 assets.

> Note: Ren'Py's own `lint` was not run (no Ren'Py binary in this environment), so a quick `renpy.sh game/ lint` before merge is recommended.

https://claude.ai/code/session_01C7vHD5MRc7JWtvDzrcW5Hn


---
_Generated by [Claude Code](https://claude.ai/code/session_01C7vHD5MRc7JWtvDzrcW5Hn)_