### PR TITLE
Fix main CI: scope Tradition/paradigm tests to core Traditions

### DIFF
--- a/tests/test_chargen.py
+++ b/tests/test_chargen.py
@@ -334,11 +334,14 @@ class TestTraditionTemplates:
 
     def test_all_nine_traditions_present(self, mage_splat):
         names = {t["name"] for t in mage_splat.chargen_config["traditions"]}
-        assert names == {
+        # The nine core Traditions must always be offered. Quasi-Traditions
+        # (Hollow Ones) and unaffiliated mages (Orphans) may also appear, so
+        # this is a subset check rather than an exact-equality one.
+        assert {
             "Akashic Brotherhood", "Celestial Chorus", "Cult of Ecstasy",
             "Dreamspeakers", "Euthanatos", "Order of Hermes",
             "Sons of Ether", "Verbena", "Virtual Adepts",
-        }
+        } <= names
 
     def test_every_tradition_has_a_template(self, mage_splat):
         for trad in mage_splat.chargen_config["traditions"]:
@@ -366,12 +369,19 @@ class TestTraditionTemplates:
         # Resources are attached and usable.
         assert char.resources is not None
         assert char.resources.has_resource("willpower")
-        # The template leads with its Tradition's affinity Sphere.
-        assert char.get(tradition["affinity_sphere"]) >= 1
+        spheres = ("Correspondence", "Entropy", "Forces", "Life", "Matter",
+                   "Mind", "Prime", "Spirit", "Time")
+        affinity = tradition["affinity_sphere"]
+        if affinity in spheres:
+            # The template leads with its Tradition's affinity Sphere.
+            assert char.get(affinity) >= 1
+        else:
+            # Orphans/Disparates have no fixed affinity ("Any"); just require
+            # that the template invests in at least one Sphere.
+            assert any(char.get(s) >= 1 for s in spheres)
         # No Sphere exceeds Arete (engine enforces this on build; assert anyway).
         arete = char.get("Arete")
-        for sphere in ("Correspondence", "Entropy", "Forces", "Life", "Matter",
-                       "Mind", "Prime", "Spirit", "Time"):
+        for sphere in spheres:
             assert char.get(sphere) <= arete
 
     @pytest.mark.parametrize("tradition,template", _TEMPLATE_PARAMS, ids=_TEMPLATE_IDS)

--- a/tests/test_paradigm.py
+++ b/tests/test_paradigm.py
@@ -286,12 +286,23 @@ class TestRealMageParadigm:
         wod_core.init(GAME_DIR)
         wod_core.load_splat("mage")
 
+    # The nine core Traditions each channel a fixed paradigm. Hollow Ones and
+    # Orphans are deliberately unaffiliated — they pick their own focus — so
+    # they carry no fixed paradigm entry and are excluded here.
+    _CORE_TRADITIONS = frozenset({
+        "akashic_brotherhood", "celestial_chorus", "cult_of_ecstasy",
+        "dreamspeakers", "euthanatos", "order_of_hermes",
+        "sons_of_ether", "verbena", "virtual_adepts",
+    })
+
     def test_schema_has_paradigm(self):
         schema = wod_core.get_loader().loaded_splats["mage"].schema
         assert schema.paradigm is not None
-        # Every Tradition in chargen.yaml has a paradigm entry.
+        # Every core Tradition in chargen.yaml has a paradigm entry.
         chargen = wod_core.get_loader().loaded_splats["mage"].chargen_config
-        for trad in chargen["traditions"]:
+        core = [t for t in chargen["traditions"] if t["id"] in self._CORE_TRADITIONS]
+        assert len(core) == 9, "expected the nine core Traditions in chargen.yaml"
+        for trad in core:
             assert schema.paradigm.methods_for(trad["id"]), trad["id"]
 
     def test_demo_virtual_adept(self):


### PR DESCRIPTION
## Summary

`main` itself is currently red: three tests fail on its HEAD. This is a parallel-merge collision — **PR #37** ("add Hollow Ones and Orphans as chargen options") added two new entries to `chargen.yaml`, but three tests written by *earlier* PRs assumed exactly the nine core Traditions. Because every workflow runs the whole suite with bare `pytest`, this breakage fails CI on **every open PR** (including #40).

This is a **test-only** fix — no production code changes.

## The three failures

| Test | Cause | Fix |
|---|---|---|
| `test_all_nine_traditions_present` | Asserted set *equality*; the 2 new traditions (11 total) broke it | Relax to a subset check — the 9 core must be present; quasi-Traditions may also appear |
| `test_template_builds[orphans-*]` (×2) | `char.get(affinity_sphere)` raised `KeyError` because Orphans' affinity is `"Any"` (no fixed affinity) | Only assert the affinity Sphere when it's a real Sphere; otherwise require the template to invest in *some* Sphere. The Orphan templates build fine — only the assertion was wrong |
| `test_schema_has_paradigm` | Iterated *every* chargen Tradition, but Hollow Ones/Orphans are deliberately unaffiliated and carry no fixed paradigm methods | Scope the assertion to the nine core Traditions |

The intent behind these fixes follows the `chargen.yaml` comments themselves, which describe Hollow Ones as a *"Quasi-Tradition"* and Orphans as *"unaffiliated mages [who] Awaken without a Tradition and choose their own affinity Sphere."*

## Testing

`python -m pytest` → **272 passed** (was 4 failed / 268 passed on `main`).

> Once this merges, PR #40 (freebie tests) goes green on rebase with no further changes.

https://claude.ai/code/session_011xhGcgHmcg667EEmLWUFt8

---
_Generated by [Claude Code](https://claude.ai/code/session_011xhGcgHmcg667EEmLWUFt8)_